### PR TITLE
Make mjolnir.useCircuitBreakers=true by default

### DIFF
--- a/Hudl.Mjolnir/Command/Command.cs
+++ b/Hudl.Mjolnir/Command/Command.cs
@@ -36,7 +36,7 @@ namespace Hudl.Mjolnir.Command
     public abstract class Command
     {
         protected static readonly ILog Log = LogManager.GetLogger(typeof(Command<>));
-        protected static readonly ConfigurableValue<bool> UseCircuitBreakers = new ConfigurableValue<bool>("mjolnir.useCircuitBreakers");
+        protected static readonly ConfigurableValue<bool> UseCircuitBreakers = new ConfigurableValue<bool>("mjolnir.useCircuitBreakers", true);
 
         /// <summary>
         /// Cache of known command names, keyed by Type and group key. Helps


### PR DESCRIPTION
The config value was originally a failsafe in case we found problems with
the breakers, and that's the only reason it really still exists. Unlikely that
it'll ever need to be false, so defaulting it to something more sensible.
