### PR TITLE
Create Hudl.Mjolnir.Attributes package

### DIFF
--- a/Hudl.Mjolnir.Attributes/CommandAttribute.cs
+++ b/Hudl.Mjolnir.Attributes/CommandAttribute.cs
@@ -1,0 +1,71 @@
+﻿using System;
+
+namespace Hudl.Mjolnir.Attributes
+{
+    /// <summary>
+    /// Used on an interface to proxy all of its method calls through a Mjolnir Command.
+    /// See Command and its constructors for more information.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Interface)]
+    public sealed class CommandAttribute : Attribute
+    {
+        private const int DefaultTimeout = 15000;
+
+        private readonly string _group;
+        private readonly string _breakerKey;
+        private readonly string _poolKey;
+        private readonly int _timeout;
+
+        // See Mjolnir's Command constructors.
+        public CommandAttribute(string group, string isolationKey, int timeout = DefaultTimeout) : this(group, isolationKey, isolationKey, timeout) { }
+
+        // See Mjolnir's Command constructors.
+        public CommandAttribute(string group, string breakerKey, string poolKey, int timeout = DefaultTimeout)
+        {
+            if (string.IsNullOrWhiteSpace(group))
+            {
+                throw new ArgumentException("group");
+            }
+
+            if (string.IsNullOrWhiteSpace(breakerKey))
+            {
+                throw new ArgumentException("breakerKey");
+            }
+
+            if (string.IsNullOrWhiteSpace(poolKey))
+            {
+                throw new ArgumentNullException("poolKey");
+            }
+
+            if (timeout < 0)
+            {
+                throw new ArgumentException("timeout");
+            }
+
+            _group = group;
+            _breakerKey = breakerKey;
+            _poolKey = poolKey;
+            _timeout = timeout;
+        }
+
+        public string Group
+        {
+            get { return _group; }
+        }
+
+        public string BreakerKey
+        {
+            get { return _breakerKey; }
+        }
+
+        public string PoolKey
+        {
+            get { return _poolKey; }
+        }
+
+        public int Timeout
+        {
+            get { return _timeout; }
+        }
+    }
+}

--- a/Hudl.Mjolnir.Attributes/CommandTimeoutAttribute.cs
+++ b/Hudl.Mjolnir.Attributes/CommandTimeoutAttribute.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace Hudl.Mjolnir.Attributes
+{
+    /// <summary>
+    /// Used to override the timeout provided by <see cref="CommandAttribute"/> 
+    /// for specific methods.
+    /// 
+    /// Should only be used on interface methods.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    public sealed class CommandTimeoutAttribute : Attribute
+    {
+        private readonly int _timeout;
+
+        public CommandTimeoutAttribute(int timeout)
+        {
+            if (timeout < 0)
+            {
+                throw new ArgumentException("timeout");
+            }
+
+            _timeout = timeout;
+        }
+
+        public int Timeout
+        {
+            get { return _timeout; }
+        }
+    }
+}

--- a/Hudl.Mjolnir.Attributes/FireAndForgetAttribute.cs
+++ b/Hudl.Mjolnir.Attributes/FireAndForgetAttribute.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Hudl.Mjolnir.Attributes
+{
+    /// <summary>
+    /// Used on methods of <see cref="CommandAttribute"/> interfaces
+    /// to indicate that the call should return immediately and execute
+    /// the method on a background thread.
+    /// 
+    /// Should only be used on interface methods.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    public class FireAndForgetAttribute : Attribute
+    {
+
+    }
+}

--- a/Hudl.Mjolnir.Attributes/Hudl.Mjolnir.Attributes.csproj
+++ b/Hudl.Mjolnir.Attributes/Hudl.Mjolnir.Attributes.csproj
@@ -1,0 +1,53 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{35789458-34E2-42D2-9FC2-043C56C3D011}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Hudl.Mjolnir.Attributes</RootNamespace>
+    <AssemblyName>Hudl.Mjolnir.Attributes</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="CommandAttribute.cs" />
+    <Compile Include="CommandTimeoutAttribute.cs" />
+    <Compile Include="FireAndForgetAttribute.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Hudl.Mjolnir.Attributes.nuspec" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Hudl.Mjolnir.Attributes/Hudl.Mjolnir.Attributes.nuspec
+++ b/Hudl.Mjolnir.Attributes/Hudl.Mjolnir.Attributes.nuspec
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+    <authors>$author$</authors>
+    <description>$description$</description>
+    <licenseUrl>https://raw.githubusercontent.com/hudl/Mjolnir/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/hudl/Mjolnir</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <tags>isolation resilience threadpool circuitbreaker</tags>
+    <iconUrl>https://raw.githubusercontent.com/hudl/Mjolnir/master/hudl.png</iconUrl>
+  </metadata>
+  <files>
+    <file src="bin\Release\$id$.dll" target="lib\net45"/>
+    <file src="bin\Release\$id$.pdb" target="lib\net45"/>
+  </files>
+</package>

--- a/Hudl.Mjolnir.Attributes/Properties/AssemblyInfo.cs
+++ b/Hudl.Mjolnir.Attributes/Properties/AssemblyInfo.cs
@@ -1,0 +1,33 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Hudl.Mjolnir.Attributes")]
+[assembly: AssemblyDescription("Supplementary attributes package for use with Hudl.Mjolnir.")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Hudl")]
+[assembly: AssemblyProduct("Hudl.Mjolnir.Attributes")]
+[assembly: AssemblyCopyright("Copyright ©  2014")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("07faf800-fc8c-476a-894c-71fb125863ef")]
+
+// Used for NuGet packaging, uses semantic versioning: major.minor.patch-prerelease.
+[assembly: AssemblyInformationalVersion("1.0.0")]
+
+// Keep this the same as AssemblyInformationalVersion.
+[assembly: AssemblyFileVersion("1.0.0")]
+
+// ONLY change this when the major version changes; never with minor/patch/build versions.
+// It'll almost always be the major version followed by three zeroes (e.g. 1.0.0.0).
+[assembly: AssemblyVersion("1.0.0.0")]

--- a/Hudl.Mjolnir.sln
+++ b/Hudl.Mjolnir.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hudl.Mjolnir.Tests", "Hudl.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hudl.Mjolnir.SystemTests", "Hudl.Mjolnir.SystemTests\Hudl.Mjolnir.SystemTests.csproj", "{12884247-4362-4F20-87A1-F259213E463C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hudl.Mjolnir.Attributes", "Hudl.Mjolnir.Attributes\Hudl.Mjolnir.Attributes.csproj", "{35789458-34E2-42D2-9FC2-043C56C3D011}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{12884247-4362-4F20-87A1-F259213E463C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{12884247-4362-4F20-87A1-F259213E463C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{12884247-4362-4F20-87A1-F259213E463C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{35789458-34E2-42D2-9FC2-043C56C3D011}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{35789458-34E2-42D2-9FC2-043C56C3D011}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{35789458-34E2-42D2-9FC2-043C56C3D011}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{35789458-34E2-42D2-9FC2-043C56C3D011}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This package will replace the command attributes included in Mjolnir proper.

Internally, we use these attributes in lightweight client packages, and we need those packages to have as few dependencies as possible to reduce coupling and transitive dependency resolution when they're imported into other projects.

Once this is pushed, I'll update Mjolnir to accommodate these attributes. The ones inside Mjolnir will become `[Obsolete]`, but will continue to work until the next major release.
