### PR TITLE
Isolate (limit concurrency) using TaskSchedulers instead of thread pools

### DIFF
--- a/Hudl.Mjolnir.Tests/Command/CommandFallbackTests.cs
+++ b/Hudl.Mjolnir.Tests/Command/CommandFallbackTests.cs
@@ -2,9 +2,9 @@
 using System.Threading.Tasks;
 using Hudl.Mjolnir.Breaker;
 using Hudl.Mjolnir.Command;
+using Hudl.Mjolnir.Isolation;
 using Hudl.Mjolnir.Tests.Helper;
 using Hudl.Mjolnir.Tests.TestCommands;
-using Hudl.Mjolnir.ThreadPool;
 using Moq;
 using Xunit;
 

--- a/Hudl.Mjolnir.Tests/Command/CommandGroupKeyTests.cs
+++ b/Hudl.Mjolnir.Tests/Command/CommandGroupKeyTests.cs
@@ -16,7 +16,7 @@ namespace Hudl.Mjolnir.Tests.Command
             var command = new KeyTestCommand("test", "foo");
 
             Assert.Equal(GroupKey.Named("foo"), command.BreakerKey);
-            Assert.Equal(GroupKey.Named("foo"), command.PoolKey);
+            Assert.Equal(GroupKey.Named("foo"), command.IsolationKey);
         }
 
         [Fact]
@@ -30,16 +30,16 @@ namespace Hudl.Mjolnir.Tests.Command
         public void Construct_WithSpecificPoolKey_UsesProvidedPoolKey()
         {
             var command = new KeyTestCommand("test", "test", "bar");
-            Assert.Equal(GroupKey.Named("bar"), command.PoolKey);
+            Assert.Equal(GroupKey.Named("bar"), command.IsolationKey);
         }
 
         private sealed class KeyTestCommand : Command<object>
         {
-            internal KeyTestCommand(string group, string isolationKey)
-                : base(group, isolationKey, TimeSpan.FromMilliseconds(10000)) { }
+            internal KeyTestCommand(string group, string breakerAndIsolationKey)
+                : base(group, breakerAndIsolationKey, TimeSpan.FromMilliseconds(10000)) { }
 
-            internal KeyTestCommand(string group, string breakerKey, string poolKey)
-                : base(group, breakerKey, poolKey, TimeSpan.FromMilliseconds(10000)) {}
+            internal KeyTestCommand(string group, string breakerKey, string isolationKey)
+                : base(group, breakerKey, isolationKey, TimeSpan.FromMilliseconds(10000)) {}
 
             protected override Task<object> ExecuteAsync(CancellationToken cancellationToken)
             {

--- a/Hudl.Mjolnir.Tests/Command/CommandThreadPoolTests.cs
+++ b/Hudl.Mjolnir.Tests/Command/CommandThreadPoolTests.cs
@@ -63,7 +63,7 @@ namespace Hudl.Mjolnir.Tests.Command
             }
             catch (CommandFailedException e)
             {
-                Assert.True(e.InnerException is IsolationThreadPoolRejectedException);
+                Assert.True(e.InnerException is IsolationStrategyRejectedException);
                 mockMetrics.Verify(m => m.MarkCommandFailure(), Times.Never);
                 mockMetrics.Verify(m => m.MarkCommandSuccess(), Times.Never);
                 return; // Expected.

--- a/Hudl.Mjolnir.Tests/Command/CommandThreadPoolTests.cs
+++ b/Hudl.Mjolnir.Tests/Command/CommandThreadPoolTests.cs
@@ -2,10 +2,10 @@
 using System.Threading.Tasks;
 using Hudl.Mjolnir.Breaker;
 using Hudl.Mjolnir.Command;
+using Hudl.Mjolnir.Isolation;
 using Hudl.Mjolnir.Metrics;
 using Hudl.Mjolnir.Tests.Helper;
 using Hudl.Mjolnir.Tests.TestCommands;
-using Hudl.Mjolnir.ThreadPool;
 using Moq;
 using Xunit;
 

--- a/Hudl.Mjolnir.Tests/Command/CommandThreadPoolTests.cs
+++ b/Hudl.Mjolnir.Tests/Command/CommandThreadPoolTests.cs
@@ -86,7 +86,7 @@ namespace Hudl.Mjolnir.Tests.Command
             Assert.True(command.FallbackCalled);
         }
 
-        private class RejectingIsolationThreadPool : IIsolationThreadPool
+        private class RejectingIsolationThreadPool : IQueuedIsolationStrategy
         {
             private readonly IsolationThreadPoolRejectedException _exceptionToThrow;
 

--- a/Hudl.Mjolnir.Tests/Command/CommandThreadPoolTests.cs
+++ b/Hudl.Mjolnir.Tests/Command/CommandThreadPoolTests.cs
@@ -22,7 +22,7 @@ namespace Hudl.Mjolnir.Tests.Command
 
             var command = new SuccessfulEchoCommandWithoutFallback(new {})
             {
-                ThreadPool = pool,
+                IsolationStrategy = pool,
             };
 
             try
@@ -53,7 +53,7 @@ namespace Hudl.Mjolnir.Tests.Command
             var command = new SuccessfulEchoCommandWithoutFallback(new { })
             {
                 CircuitBreaker = mockBreaker.Object,
-                ThreadPool = pool,
+                IsolationStrategy = pool,
             };
 
             try
@@ -79,7 +79,7 @@ namespace Hudl.Mjolnir.Tests.Command
 
             var command = new SuccessfulEchoCommandWithFallback(new { })
             {
-                ThreadPool = pool,
+                IsolationStrategy = pool,
             };
 
             await command.InvokeAsync(); // Won't throw because there's a successful fallback.

--- a/Hudl.Mjolnir.Tests/Command/CommandThreadPoolTests.cs
+++ b/Hudl.Mjolnir.Tests/Command/CommandThreadPoolTests.cs
@@ -116,6 +116,11 @@ namespace Hudl.Mjolnir.Tests.Command
                 _exceptionToThrow = exceptionToThrow;
             }
 
+            public Task Enqueue(Action action, CancellationToken cancellationToken)
+            {
+                throw _exceptionToThrow;
+            }
+
             public Task<TResult> Enqueue<TResult>(Func<TResult> func, CancellationToken cancellationToken)
             {
                 throw _exceptionToThrow;

--- a/Hudl.Mjolnir.Tests/Helper/AlwaysSuccessfulIsolationSemaphore.cs
+++ b/Hudl.Mjolnir.Tests/Helper/AlwaysSuccessfulIsolationSemaphore.cs
@@ -1,4 +1,4 @@
-﻿using Hudl.Mjolnir.ThreadPool;
+﻿using Hudl.Mjolnir.Isolation;
 
 namespace Hudl.Mjolnir.Tests.Helper
 {

--- a/Hudl.Mjolnir.Tests/Helper/AlwaysSuccessfulIsolationThreadPool.cs
+++ b/Hudl.Mjolnir.Tests/Helper/AlwaysSuccessfulIsolationThreadPool.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Threading;
-using Hudl.Mjolnir.ThreadPool;
+using Hudl.Mjolnir.Isolation;
 
 namespace Hudl.Mjolnir.Tests.Helper
 {

--- a/Hudl.Mjolnir.Tests/Helper/AlwaysSuccessfulIsolationThreadPool.cs
+++ b/Hudl.Mjolnir.Tests/Helper/AlwaysSuccessfulIsolationThreadPool.cs
@@ -4,7 +4,7 @@ using Hudl.Mjolnir.Isolation;
 
 namespace Hudl.Mjolnir.Tests.Helper
 {
-    internal class AlwaysSuccessfulIsolationThreadPool : IQueuedIsolationStrategy
+    internal class AlwaysSuccessfulIsolationThreadPool : IIsolationThreadPool
     {
         public void Start()
         {

--- a/Hudl.Mjolnir.Tests/Helper/AlwaysSuccessfulIsolationThreadPool.cs
+++ b/Hudl.Mjolnir.Tests/Helper/AlwaysSuccessfulIsolationThreadPool.cs
@@ -4,7 +4,7 @@ using Hudl.Mjolnir.Isolation;
 
 namespace Hudl.Mjolnir.Tests.Helper
 {
-    internal class AlwaysSuccessfulIsolationThreadPool : IIsolationThreadPool
+    internal class AlwaysSuccessfulIsolationThreadPool : IQueuedIsolationStrategy
     {
         public void Start()
         {

--- a/Hudl.Mjolnir.Tests/Helper/AlwaysSuccessfulQueuedIsolationStrategy.cs
+++ b/Hudl.Mjolnir.Tests/Helper/AlwaysSuccessfulQueuedIsolationStrategy.cs
@@ -7,6 +7,12 @@ namespace Hudl.Mjolnir.Tests.Helper
 {
     internal class AlwaysSuccessfulQueuedIsolationStrategy : IQueuedIsolationStrategy
     {
+        public Task Enqueue(Action action, CancellationToken cancellationToken)
+        {
+            // Use the default scheduler, which doesn't enforce concurrency.
+            return Task.Factory.StartNew(action, cancellationToken);
+        }
+
         public Task<TResult> Enqueue<TResult>(Func<TResult> func, CancellationToken cancellationToken)
         {
             // Use the default scheduler, which doesn't enforce concurrency.

--- a/Hudl.Mjolnir.Tests/Helper/AlwaysSuccessfulQueuedIsolationStrategy.cs
+++ b/Hudl.Mjolnir.Tests/Helper/AlwaysSuccessfulQueuedIsolationStrategy.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Hudl.Mjolnir.Isolation;
+
+namespace Hudl.Mjolnir.Tests.Helper
+{
+    internal class AlwaysSuccessfulQueuedIsolationStrategy : IQueuedIsolationStrategy
+    {
+        public Task<TResult> Enqueue<TResult>(Func<TResult> func, CancellationToken cancellationToken)
+        {
+            // Use the default scheduler, which doesn't enforce concurrency.
+            return Task.Factory.StartNew(func, cancellationToken);
+        }
+    }
+}

--- a/Hudl.Mjolnir.Tests/Hudl.Mjolnir.Tests.csproj
+++ b/Hudl.Mjolnir.Tests/Hudl.Mjolnir.Tests.csproj
@@ -84,6 +84,7 @@
     <Compile Include="Helper\AlwaysSuccessfulCircuitBreaker.cs" />
     <Compile Include="Helper\AlwaysSuccessfulIsolationSemaphore.cs" />
     <Compile Include="Helper\AlwaysSuccessfulIsolationThreadPool.cs" />
+    <Compile Include="Helper\AlwaysSuccessfulQueuedIsolationStrategy.cs" />
     <Compile Include="Helper\AssertX.cs" />
     <Compile Include="Helper\ExpectedTestException.cs" />
     <Compile Include="Helper\TestFixture.cs" />

--- a/Hudl.Mjolnir.Tests/Hudl.Mjolnir.Tests.csproj
+++ b/Hudl.Mjolnir.Tests/Hudl.Mjolnir.Tests.csproj
@@ -111,9 +111,9 @@
     <Compile Include="TestCommands\SuccessfulEchoCommandWithoutFallback.cs" />
     <Compile Include="TestCommands\TimingOutCommand.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="ThreadPool\SemaphoreSlimIsolationSemaphoreTests.cs" />
-    <Compile Include="ThreadPool\StpIsolationThreadPoolTests.cs" />
-    <Compile Include="ThreadPool\StpWorkItemTests.cs" />
+    <Compile Include="Isolation\SemaphoreSlimIsolationSemaphoreTests.cs" />
+    <Compile Include="Isolation\StpIsolationThreadPoolTests.cs" />
+    <Compile Include="Isolation\StpWorkItemTests.cs" />
     <Compile Include="Util\ConcurrentDictionaryExtensionsTests.cs" />
     <Compile Include="Util\TestConfigProvider.cs" />
   </ItemGroup>

--- a/Hudl.Mjolnir.Tests/Hudl.Mjolnir.Tests.csproj
+++ b/Hudl.Mjolnir.Tests/Hudl.Mjolnir.Tests.csproj
@@ -88,6 +88,7 @@
     <Compile Include="Helper\AssertX.cs" />
     <Compile Include="Helper\ExpectedTestException.cs" />
     <Compile Include="Helper\TestFixture.cs" />
+    <Compile Include="Isolation\TaskSchedulerQueuedIsolationTests.cs" />
     <Compile Include="Key\GroupKeyTests.cs" />
     <Compile Include="Metrics\InterlockingLongCounterTests.cs" />
     <Compile Include="Metrics\ResettingNumbersBucketTests.cs" />

--- a/Hudl.Mjolnir.Tests/Isolation/SemaphoreSlimIsolationSemaphoreTests.cs
+++ b/Hudl.Mjolnir.Tests/Isolation/SemaphoreSlimIsolationSemaphoreTests.cs
@@ -1,12 +1,12 @@
 ﻿using System.Diagnostics;
 using Hudl.Config;
 using Hudl.Mjolnir.External;
+using Hudl.Mjolnir.Isolation;
 using Hudl.Mjolnir.Key;
 using Hudl.Mjolnir.Tests.Helper;
-using Hudl.Mjolnir.ThreadPool;
 using Xunit;
 
-namespace Hudl.Mjolnir.Tests.ThreadPool
+namespace Hudl.Mjolnir.Tests.Isolation
 {
     public class SemaphoreSlimIsolationSemaphoreTests : TestFixture
     {

--- a/Hudl.Mjolnir.Tests/Isolation/StpIsolationThreadPoolTests.cs
+++ b/Hudl.Mjolnir.Tests/Isolation/StpIsolationThreadPoolTests.cs
@@ -2,12 +2,12 @@
 using System.Threading;
 using Hudl.Config;
 using Hudl.Mjolnir.External;
+using Hudl.Mjolnir.Isolation;
 using Hudl.Mjolnir.Key;
 using Hudl.Mjolnir.Tests.Helper;
-using Hudl.Mjolnir.ThreadPool;
 using Xunit;
 
-namespace Hudl.Mjolnir.Tests.ThreadPool
+namespace Hudl.Mjolnir.Tests.Isolation
 {
     public class StpIsolationThreadPoolTests : TestFixture
     {

--- a/Hudl.Mjolnir.Tests/Isolation/StpIsolationThreadPoolTests.cs
+++ b/Hudl.Mjolnir.Tests/Isolation/StpIsolationThreadPoolTests.cs
@@ -15,10 +15,10 @@ namespace Hudl.Mjolnir.Tests.Isolation
         public void Enqueue_PoolSizeOneQueueSizeZero_AcceptsOneAndRejectsRemaining()
         {
             var pool = CreateAndStartPool(1, 0);
-            pool.Enqueue(SleepThreeSeconds);
+            pool.Enqueue(SleepTwoSeconds);
             Assert.Throws<IsolationThreadPoolRejectedException>(() =>
             {
-                pool.Enqueue(SleepThreeSeconds);
+                pool.Enqueue(SleepTwoSeconds);
             });
         }
 
@@ -26,11 +26,11 @@ namespace Hudl.Mjolnir.Tests.Isolation
         public void Enqueue_PoolSizeOneQueueSizeOne_AcceptsTwoAndRejectsRemaining()
         {
             var pool = CreateAndStartPool(1, 1);
-            pool.Enqueue(SleepThreeSeconds);
-            pool.Enqueue(SleepThreeSeconds);
+            pool.Enqueue(SleepTwoSeconds);
+            pool.Enqueue(SleepTwoSeconds);
             Assert.Throws<IsolationThreadPoolRejectedException>(() =>
             {
-                pool.Enqueue(SleepThreeSeconds);
+                pool.Enqueue(SleepTwoSeconds);
             });
         }
 
@@ -38,15 +38,15 @@ namespace Hudl.Mjolnir.Tests.Isolation
         public void Enqueue_PoolSizeFiveQueueSizeOne_AcceptsSixAndRejectsRemaining()
         {
             var pool = CreateAndStartPool(5, 1);
-            pool.Enqueue(SleepThreeSeconds);
-            pool.Enqueue(SleepThreeSeconds);
-            pool.Enqueue(SleepThreeSeconds);
-            pool.Enqueue(SleepThreeSeconds);
-            pool.Enqueue(SleepThreeSeconds);
-            pool.Enqueue(SleepThreeSeconds);
+            pool.Enqueue(SleepTwoSeconds);
+            pool.Enqueue(SleepTwoSeconds);
+            pool.Enqueue(SleepTwoSeconds);
+            pool.Enqueue(SleepTwoSeconds);
+            pool.Enqueue(SleepTwoSeconds);
+            pool.Enqueue(SleepTwoSeconds);
             Assert.Throws<IsolationThreadPoolRejectedException>(() =>
             {
-                pool.Enqueue(SleepThreeSeconds);
+                pool.Enqueue(SleepTwoSeconds);
             });
         }
 
@@ -59,7 +59,7 @@ namespace Hudl.Mjolnir.Tests.Isolation
             pool.Enqueue(ReturnImmediately); // Shouldn't be rejected.
         }
 
-        private object SleepThreeSeconds()
+        private object SleepTwoSeconds()
         {
             Thread.Sleep(TimeSpan.FromSeconds(2));
             return new {};

--- a/Hudl.Mjolnir.Tests/Isolation/StpWorkItemTests.cs
+++ b/Hudl.Mjolnir.Tests/Isolation/StpWorkItemTests.cs
@@ -1,13 +1,12 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Threading;
 using Amib.Threading;
+using Hudl.Mjolnir.Isolation;
 using Hudl.Mjolnir.Tests.Helper;
-using Hudl.Mjolnir.ThreadPool;
 using Moq;
 using Xunit;
 
-namespace Hudl.Mjolnir.Tests.ThreadPool
+namespace Hudl.Mjolnir.Tests.Isolation
 {
     public class StpWorkItemTests : TestFixture
     {

--- a/Hudl.Mjolnir.Tests/Isolation/TaskSchedulerQueuedIsolationTests.cs
+++ b/Hudl.Mjolnir.Tests/Isolation/TaskSchedulerQueuedIsolationTests.cs
@@ -1,8 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
+using Hudl.Config;
+using Hudl.Mjolnir.Isolation;
 using Xunit;
 
 namespace Hudl.Mjolnir.Tests.Isolation
@@ -10,9 +11,126 @@ namespace Hudl.Mjolnir.Tests.Isolation
     public class TaskSchedulerQueuedIsolationTests
     {
         [Fact]
-        public void TestSomething()
+        public void Construct_MaxConcurrency_ArgumentValidation()
         {
-            
+            var maxQueueLength = new TransientConfigurableValue<int>(1); // Good value for queue length, not testing it here.
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => new QueuedTaskSchedulerIsolationStrategy(new TransientConfigurableValue<int>(0), maxQueueLength));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new QueuedTaskSchedulerIsolationStrategy(new TransientConfigurableValue<int>(-1), maxQueueLength));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new QueuedTaskSchedulerIsolationStrategy(new TransientConfigurableValue<int>(Int32.MinValue), maxQueueLength));
+            Assert.DoesNotThrow(() => new QueuedTaskSchedulerIsolationStrategy(new TransientConfigurableValue<int>(1), maxQueueLength));
+            Assert.DoesNotThrow(() => new QueuedTaskSchedulerIsolationStrategy(new TransientConfigurableValue<int>(Int32.MaxValue), maxQueueLength));
         }
+
+        [Fact]
+        public void Construct_MaxQueueLength_ArgumentValidation()
+        {
+            var maxConcurrency = new TransientConfigurableValue<int>(1); // Good value for max concurrency, not testing it here.
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => new QueuedTaskSchedulerIsolationStrategy(maxConcurrency, new TransientConfigurableValue<int>(-1)));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new QueuedTaskSchedulerIsolationStrategy(maxConcurrency, new TransientConfigurableValue<int>(Int32.MinValue)));
+            Assert.DoesNotThrow(() => new QueuedTaskSchedulerIsolationStrategy(maxConcurrency, new TransientConfigurableValue<int>(0)));
+            Assert.DoesNotThrow(() => new QueuedTaskSchedulerIsolationStrategy(maxConcurrency, new TransientConfigurableValue<int>(1)));
+            Assert.DoesNotThrow(() => new QueuedTaskSchedulerIsolationStrategy(maxConcurrency, new TransientConfigurableValue<int>(Int32.MaxValue)));
+        }
+
+        [Fact]
+        public void Enqueue_MaxConcurrencyOne_QueueLengthZero_AcceptsOneAndRejectsRemaining()
+        {
+            RunEnqueueTest(1, 0);
+        }
+
+        [Fact]
+        public void Enqueue_MaxConcurrencyOne_QueueLengthOne_AcceptsTwoAndRejectsRemaining()
+        {
+            RunEnqueueTest(1, 1);
+        }
+
+        [Fact]
+        public void Enqueue_MaxConcurrencyFive_QueueLengthOne_AcceptsSixAndRejectsRemaining()
+        {
+            RunEnqueueTest(5, 1);
+        }
+
+        [Fact]
+        public void Enqueue_AfterOneTaskCompletes_AcceptsMore()
+        {
+            var isolation = CreateIsolation(1, 0);
+            Assert.DoesNotThrow(() => isolation.Enqueue(ReturnImmediately, CancellationToken.None));
+            Thread.Sleep(10); // Make sure it completes (by hacky-sleeping and hoping that's enough).
+            Assert.DoesNotThrow(() => isolation.Enqueue(ReturnImmediately, CancellationToken.None));
+        }
+
+        // TODO Make sure that the counts are maintained when a task throws exceptions.
+        // - Run a test that counts a bunch and verify that it zeroes out under high concurrency after it's done.
+
+        // TODO Consideration for attached/detached child tasks.
+
+        // TODO Consideration for ThreadPool size. Should we actually be using the application pool, or instead manage our own?
+        // - A risk point is pushing up on the application pool max (or current size). How fast does it scale?
+        // - Get some metrics on current pool usage in production.
+
+        //[Fact]
+        //public void Blah()
+        //{
+        //    var isolation = new QueuedTaskSchedulerIsolationStrategy(new TransientConfigurableValue<int>(3), new TransientConfigurableValue<int>(1));
+
+        //    // One executes immediately, one queued.
+        //    isolation.Enqueue(SleepTwoSeconds, CancellationToken.None);
+        //    isolation.Enqueue(SleepTwoSeconds, CancellationToken.None);
+        //    isolation.Enqueue(SleepTwoSeconds, CancellationToken.None);
+        //    isolation.Enqueue(SleepTwoSeconds, CancellationToken.None);
+        //    isolation.Enqueue(SleepTwoSeconds, CancellationToken.None);
+        //    isolation.Enqueue(SleepTwoSeconds, CancellationToken.None);
+        //    isolation.Enqueue(SleepTwoSeconds, CancellationToken.None);
+
+        //}
+
+        private static void RunEnqueueTest(int maxConcurrency, int maxQueueLength)
+        {
+            var isolation = CreateIsolation(maxConcurrency, maxQueueLength);
+
+            for (var i = 0; i < maxConcurrency + maxQueueLength; i++)
+            {
+                Assert.DoesNotThrow(() => isolation.Enqueue(SleepTwoSeconds, CancellationToken.None));
+            }
+
+            var e = Assert.Throws<IsolationStrategyRejectedException>(() => isolation.Enqueue(SleepTwoSeconds, CancellationToken.None));
+
+            // Assumes *none* of the tasks have completed yet (an assumption that all of these tests make).
+            Assert.Equal(maxConcurrency + maxQueueLength, e.Data[QueueLengthExceededException.PendingCompletionDataKey]);
+            
+            // We don't know *exactly* how many are queued. It could actually be up to _maxParallel + _maxQueueLength if
+            // no tasks have started executing yet. Probably don't need to continue asserting this. There may be some other
+            // assertion we can replace it with, though.
+            //Assert.Equal(maxQueueLength, e.Data[QueueLengthExceededException.CurrentlyQueuedDataKey]);
+        }
+
+        private static QueuedTaskSchedulerIsolationStrategy CreateIsolation(int maxConcurrency, int maxQueueLength)
+        {
+            return new QueuedTaskSchedulerIsolationStrategy(new TransientConfigurableValue<int>(maxConcurrency), new TransientConfigurableValue<int>(maxQueueLength));
+        }
+
+        // TODO these don't hang the tests. why? i feel like they should.
+        private static object SleepTwoSeconds()
+        {
+            Thread.Sleep(TimeSpan.FromSeconds(2));
+            return new { };
+        }
+
+        private static object ReturnImmediately()
+        {
+            return new { };
+        }
+
+        // TODO Also test with some objects that:
+        // - Throw exceptions immediately
+        // - Throw exceptions from an async/await call
+        // - Throw exceptions from async when not awaited
+        // - Return values from an awaited async call
+        // - Return an async Task that's not awaited
+        // - Tasks (async and/or awaited) that get canceled via CancellationToken.
+        // - TaskScheduler throws an exception that's not a QueueLengthExceededException
+        // - Null tasks
     }
 }

--- a/Hudl.Mjolnir.Tests/Isolation/TaskSchedulerQueuedIsolationTests.cs
+++ b/Hudl.Mjolnir.Tests/Isolation/TaskSchedulerQueuedIsolationTests.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Hudl.Mjolnir.Tests.Isolation
+{
+    public class TaskSchedulerQueuedIsolationTests
+    {
+        [Fact]
+        public void TestSomething()
+        {
+            
+        }
+    }
+}

--- a/Hudl.Mjolnir.Tests/Isolation/TaskSchedulerQueuedIsolationTests.cs
+++ b/Hudl.Mjolnir.Tests/Isolation/TaskSchedulerQueuedIsolationTests.cs
@@ -4,8 +4,11 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Hudl.Config;
+using Hudl.Mjolnir.External;
 using Hudl.Mjolnir.Isolation;
+using Hudl.Mjolnir.Key;
 using Hudl.Mjolnir.Tests.Helper;
+using Moq;
 using Xunit;
 
 namespace Hudl.Mjolnir.Tests.Isolation
@@ -17,11 +20,11 @@ namespace Hudl.Mjolnir.Tests.Isolation
         {
             var maxQueueLength = new TransientConfigurableValue<int>(1); // Good value for queue length, not testing it here.
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => new QueuedTaskSchedulerIsolationStrategy(new TransientConfigurableValue<int>(0), maxQueueLength));
-            Assert.Throws<ArgumentOutOfRangeException>(() => new QueuedTaskSchedulerIsolationStrategy(new TransientConfigurableValue<int>(-1), maxQueueLength));
-            Assert.Throws<ArgumentOutOfRangeException>(() => new QueuedTaskSchedulerIsolationStrategy(new TransientConfigurableValue<int>(Int32.MinValue), maxQueueLength));
-            Assert.DoesNotThrow(() => new QueuedTaskSchedulerIsolationStrategy(new TransientConfigurableValue<int>(1), maxQueueLength));
-            Assert.DoesNotThrow(() => new QueuedTaskSchedulerIsolationStrategy(new TransientConfigurableValue<int>(Int32.MaxValue), maxQueueLength));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new QueuedTaskSchedulerIsolationStrategy(GroupKey.Named("foo"), new TransientConfigurableValue<int>(0), maxQueueLength, new Mock<IStats>().Object));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new QueuedTaskSchedulerIsolationStrategy(GroupKey.Named("foo"), new TransientConfigurableValue<int>(-1), maxQueueLength, new Mock<IStats>().Object));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new QueuedTaskSchedulerIsolationStrategy(GroupKey.Named("foo"), new TransientConfigurableValue<int>(Int32.MinValue), maxQueueLength, new Mock<IStats>().Object));
+            Assert.DoesNotThrow(() => new QueuedTaskSchedulerIsolationStrategy(GroupKey.Named("foo"), new TransientConfigurableValue<int>(1), maxQueueLength, new Mock<IStats>().Object));
+            Assert.DoesNotThrow(() => new QueuedTaskSchedulerIsolationStrategy(GroupKey.Named("foo"), new TransientConfigurableValue<int>(Int32.MaxValue), maxQueueLength, new Mock<IStats>().Object));
         }
 
         [Fact]
@@ -29,11 +32,11 @@ namespace Hudl.Mjolnir.Tests.Isolation
         {
             var maxConcurrency = new TransientConfigurableValue<int>(1); // Good value for max concurrency, not testing it here.
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => new QueuedTaskSchedulerIsolationStrategy(maxConcurrency, new TransientConfigurableValue<int>(-1)));
-            Assert.Throws<ArgumentOutOfRangeException>(() => new QueuedTaskSchedulerIsolationStrategy(maxConcurrency, new TransientConfigurableValue<int>(Int32.MinValue)));
-            Assert.DoesNotThrow(() => new QueuedTaskSchedulerIsolationStrategy(maxConcurrency, new TransientConfigurableValue<int>(0)));
-            Assert.DoesNotThrow(() => new QueuedTaskSchedulerIsolationStrategy(maxConcurrency, new TransientConfigurableValue<int>(1)));
-            Assert.DoesNotThrow(() => new QueuedTaskSchedulerIsolationStrategy(maxConcurrency, new TransientConfigurableValue<int>(Int32.MaxValue)));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new QueuedTaskSchedulerIsolationStrategy(GroupKey.Named("foo"), maxConcurrency, new TransientConfigurableValue<int>(-1), new Mock<IStats>().Object));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new QueuedTaskSchedulerIsolationStrategy(GroupKey.Named("foo"), maxConcurrency, new TransientConfigurableValue<int>(Int32.MinValue), new Mock<IStats>().Object));
+            Assert.DoesNotThrow(() => new QueuedTaskSchedulerIsolationStrategy(GroupKey.Named("foo"), maxConcurrency, new TransientConfigurableValue<int>(0), new Mock<IStats>().Object));
+            Assert.DoesNotThrow(() => new QueuedTaskSchedulerIsolationStrategy(GroupKey.Named("foo"), maxConcurrency, new TransientConfigurableValue<int>(1), new Mock<IStats>().Object));
+            Assert.DoesNotThrow(() => new QueuedTaskSchedulerIsolationStrategy(GroupKey.Named("foo"), maxConcurrency, new TransientConfigurableValue<int>(Int32.MaxValue), new Mock<IStats>().Object));
         }
 
         [Fact]
@@ -204,7 +207,7 @@ namespace Hudl.Mjolnir.Tests.Isolation
 
         private static QueuedTaskSchedulerIsolationStrategy CreateIsolation(int maxConcurrency, int maxQueueLength)
         {
-            return new QueuedTaskSchedulerIsolationStrategy(new TransientConfigurableValue<int>(maxConcurrency), new TransientConfigurableValue<int>(maxQueueLength));
+            return new QueuedTaskSchedulerIsolationStrategy(GroupKey.Named("foo"), new TransientConfigurableValue<int>(maxConcurrency), new TransientConfigurableValue<int>(maxQueueLength), new Mock<IStats>().Object);
         }
 
         // TODO Sleeping is janky. It'd be better to wire in a TaskCompletionSource and control their lifecycle that way.

--- a/Hudl.Mjolnir.Tests/Stats/SemaphoreSlimIsolationSemaphoreStatsTests.cs
+++ b/Hudl.Mjolnir.Tests/Stats/SemaphoreSlimIsolationSemaphoreStatsTests.cs
@@ -2,9 +2,9 @@
 using System.Threading.Tasks;
 using Hudl.Config;
 using Hudl.Mjolnir.External;
+using Hudl.Mjolnir.Isolation;
 using Hudl.Mjolnir.Key;
 using Hudl.Mjolnir.Tests.Helper;
-using Hudl.Mjolnir.ThreadPool;
 using Moq;
 using Xunit;
 

--- a/Hudl.Mjolnir.Tests/Stats/StpIsolationThreadPoolStatsTests.cs
+++ b/Hudl.Mjolnir.Tests/Stats/StpIsolationThreadPoolStatsTests.cs
@@ -2,9 +2,9 @@
 using System.Threading.Tasks;
 using Hudl.Config;
 using Hudl.Mjolnir.External;
+using Hudl.Mjolnir.Isolation;
 using Hudl.Mjolnir.Key;
 using Hudl.Mjolnir.Tests.Helper;
-using Hudl.Mjolnir.ThreadPool;
 using Moq;
 using Xunit;
 

--- a/Hudl.Mjolnir.Tests/TestCommands/BaseTestCommand.cs
+++ b/Hudl.Mjolnir.Tests/TestCommands/BaseTestCommand.cs
@@ -14,7 +14,7 @@ namespace Hudl.Mjolnir.Tests.TestCommands
         {
             Stats = new IgnoringStats();
             CircuitBreaker = new AlwaysSuccessfulCircuitBreaker();
-            ThreadPool = new AlwaysSuccessfulIsolationThreadPool();
+            IsolationStrategy = new AlwaysSuccessfulIsolationThreadPool();
             FallbackSemaphore = new AlwaysSuccessfulIsolationSemaphore();
         }
     }

--- a/Hudl.Mjolnir.Tests/TestCommands/BaseTestCommand.cs
+++ b/Hudl.Mjolnir.Tests/TestCommands/BaseTestCommand.cs
@@ -14,7 +14,7 @@ namespace Hudl.Mjolnir.Tests.TestCommands
         {
             Stats = new IgnoringStats();
             CircuitBreaker = new AlwaysSuccessfulCircuitBreaker();
-            IsolationStrategy = new AlwaysSuccessfulIsolationThreadPool();
+            IsolationStrategy = new AlwaysSuccessfulQueuedIsolationStrategy();
             FallbackSemaphore = new AlwaysSuccessfulIsolationSemaphore();
         }
     }

--- a/Hudl.Mjolnir/Command/Attribute/InvocationCommand.cs
+++ b/Hudl.Mjolnir/Command/Attribute/InvocationCommand.cs
@@ -16,8 +16,8 @@ namespace Hudl.Mjolnir.Command.Attribute
     {
         private readonly IInvocation _invocation;
 
-        internal InvocationCommand(string group, string name, string breakerKey, string poolKey, int timeout, IInvocation invocation)
-            : base(group, name, breakerKey, poolKey, TimeSpan.FromMilliseconds(timeout))
+        internal InvocationCommand(string group, string name, string breakerKey, string isolationKey, int timeout, IInvocation invocation)
+            : base(group, name, breakerKey, isolationKey, TimeSpan.FromMilliseconds(timeout))
         {
             _invocation = invocation;
         }

--- a/Hudl.Mjolnir/Command/Command.cs
+++ b/Hudl.Mjolnir/Command/Command.cs
@@ -93,11 +93,11 @@ namespace Hudl.Mjolnir.Command
             set { _breaker = value; }
         }
 
-        private IQueuedIsolationStrategy _pool;
+        private IQueuedIsolationStrategy _isolationStrategy;
         internal IQueuedIsolationStrategy IsolationStrategy
         {
-            private get { return _pool ?? CommandContext.GetIsolationStrategy(_isolationKey); }
-            set { _pool = value; }
+            private get { return _isolationStrategy ?? CommandContext.GetIsolationStrategy(_isolationKey); }
+            set { _isolationStrategy = value; }
         }
 
         private IIsolationSemaphore _fallbackSemaphore;

--- a/Hudl.Mjolnir/Command/Command.cs
+++ b/Hudl.Mjolnir/Command/Command.cs
@@ -93,8 +93,8 @@ namespace Hudl.Mjolnir.Command
             set { _breaker = value; }
         }
 
-        private IIsolationThreadPool _pool;
-        internal IIsolationThreadPool ThreadPool
+        private IQueuedIsolationStrategy _pool;
+        internal IQueuedIsolationStrategy ThreadPool
         {
             private get { return _pool ?? CommandContext.GetThreadPool(_poolKey); }
             set { _pool = value; }

--- a/Hudl.Mjolnir/Command/Command.cs
+++ b/Hudl.Mjolnir/Command/Command.cs
@@ -75,7 +75,7 @@ namespace Hudl.Mjolnir.Command
         private readonly GroupKey _group;
         private readonly string _name;
         private readonly GroupKey _breakerKey;
-        private readonly GroupKey _poolKey;
+        private readonly GroupKey _isolationKey;
 
         // Setters should be used for testing only.
 
@@ -96,7 +96,7 @@ namespace Hudl.Mjolnir.Command
         private IQueuedIsolationStrategy _pool;
         internal IQueuedIsolationStrategy IsolationStrategy
         {
-            private get { return _pool ?? CommandContext.GetThreadPool(_poolKey); }
+            private get { return _pool ?? CommandContext.GetIsolationStrategy(_isolationKey); }
             set { _pool = value; }
         }
 
@@ -104,7 +104,7 @@ namespace Hudl.Mjolnir.Command
         internal IIsolationSemaphore FallbackSemaphore
         {
             // TODO Consider isolating these per-command instead of per-pool.
-            private get { return _fallbackSemaphore ?? CommandContext.GetFallbackSemaphore(_poolKey); }
+            private get { return _fallbackSemaphore ?? CommandContext.GetFallbackSemaphore(_isolationKey); }
             set { _fallbackSemaphore = value; }
         }
 
@@ -117,8 +117,8 @@ namespace Hudl.Mjolnir.Command
         /// The group is used as part of the Command's <see cref="Name">Name</see>.
         /// If the group contains dots, they'll be converted to dashes.
         /// 
-        /// The provided <code>isolationKey</code> will be used as both the
-        /// breaker and pool keys.
+        /// The provided <code>breakerAndIsolationKey</code> will be used as both the
+        /// breaker and isolation strategy keys.
         /// 
         /// Command timeouts can be configured at runtime. Configuration keys
         /// follow the form: <code>mjolnir.group-key.CommandClassName.Timeout</code>
@@ -127,10 +127,10 @@ namespace Hudl.Mjolnir.Command
         /// 
         /// </summary>
         /// <param name="group">Logical grouping for the command, usually the owning team. Avoid using dots.</param>
-        /// <param name="isolationKey">Breaker and pool key to use.</param>
+        /// <param name="breakerAndIsolationKey">Named breaker and isolation strategy key to use.</param>
         /// <param name="defaultTimeout">Timeout to enforce if not otherwise configured.</param>
-        protected Command(string group, string isolationKey, TimeSpan defaultTimeout)
-            : this(group, null, isolationKey, isolationKey, defaultTimeout) {}
+        protected Command(string group, string breakerAndIsolationKey, TimeSpan defaultTimeout)
+            : this(group, null, breakerAndIsolationKey, breakerAndIsolationKey, defaultTimeout) {}
 
         /// <summary>
         /// Constructs the Command.
@@ -145,13 +145,13 @@ namespace Hudl.Mjolnir.Command
         /// 
         /// </summary>
         /// <param name="group">Logical grouping for the command, usually the owning team. Avoid using dots.</param>
-        /// <param name="breakerKey">Breaker to use for this command.</param>
-        /// <param name="poolKey">Pool to use for this command.</param>
+        /// <param name="breakerKey">Named breaker group to use for this command.</param>
+        /// <param name="isolationKey">Named isolation strategy group to use for this command.</param>
         /// <param name="defaultTimeout">Timeout to enforce if not otherwise configured.</param>
-        protected Command(string group, string breakerKey, string poolKey, TimeSpan defaultTimeout)
-            : this(group, null, breakerKey, poolKey, defaultTimeout) {}
+        protected Command(string group, string breakerKey, string isolationKey, TimeSpan defaultTimeout)
+            : this(group, null, breakerKey, isolationKey, defaultTimeout) {}
 
-        internal Command(string group, string name, string breakerKey, string poolKey, TimeSpan defaultTimeout)
+        internal Command(string group, string name, string breakerKey, string isolationKey, TimeSpan defaultTimeout)
         {
             if (string.IsNullOrWhiteSpace(group))
             {
@@ -163,9 +163,9 @@ namespace Hudl.Mjolnir.Command
                 throw new ArgumentNullException("breakerKey");
             }
 
-            if (string.IsNullOrWhiteSpace(poolKey))
+            if (string.IsNullOrWhiteSpace(isolationKey))
             {
-                throw new ArgumentNullException("poolKey");
+                throw new ArgumentNullException("isolationKey");
             }
 
             if (defaultTimeout.TotalMilliseconds <= 0)
@@ -176,7 +176,7 @@ namespace Hudl.Mjolnir.Command
             _group = GroupKey.Named(group);
             _name = string.IsNullOrWhiteSpace(name) ? GenerateAndCacheName(Group) : CacheProvidedName(Group, name);
             _breakerKey = GroupKey.Named(breakerKey);
-            _poolKey = GroupKey.Named(poolKey);
+            _isolationKey = GroupKey.Named(isolationKey);
 
             var timeout = GetTimeoutConfigurableValue(_name).Value;
             if (timeout <= 0)
@@ -231,9 +231,9 @@ namespace Hudl.Mjolnir.Command
             get { return _breakerKey; }
         }
 
-        internal GroupKey PoolKey
+        internal GroupKey IsolationKey
         {
-            get { return _poolKey; }
+            get { return _isolationKey; }
         }
 
         private string StatsPrefix
@@ -283,7 +283,7 @@ namespace Hudl.Mjolnir.Command
             var status = CommandCompletionStatus.RanToCompletion;
             try
             {
-                Log.InfoFormat("InvokeAsync Command={0} Breaker={1} Pool={2} Timeout={3}", Name, BreakerKey, PoolKey, Timeout.TotalMilliseconds);
+                Log.InfoFormat("InvokeAsync Command={0} Breaker={1} Isolation={2} Timeout={3}", Name, BreakerKey, IsolationKey, Timeout.TotalMilliseconds);
 
                 var cancellationTokenSource = new CancellationTokenSource(Timeout);
                 // Note: this actually awaits the *enqueueing* of the task, not the task execution itself.
@@ -302,7 +302,7 @@ namespace Hudl.Mjolnir.Command
                     Timeout = Timeout.TotalMilliseconds,
                     Status = status,
                     Breaker = BreakerKey,
-                    Pool = PoolKey,
+                    Pool = IsolationKey, // TODO deprecate and replace with "Isolation" something
                 });
 
                 // We don't log the exception here - that's intentional.
@@ -327,11 +327,11 @@ namespace Hudl.Mjolnir.Command
 
         private Task<TResult> ExecuteInIsolation(CancellationToken cancellationToken)
         {
-            // Note: Thread pool rejections shouldn't count as failures to the breaker.
-            // If a downstream dependency is slow, the pool will fill up, but the
-            // breaker + timeouts will already be providing protection against that.
-            // If the pool is filling up because of a surge of requests, the rejections
-            // will just be a way of shedding load - the breaker and downstream
+            // Note: Isolation rejections shouldn't count as failures to the breaker.
+            // If a downstream dependency is slow, the queue/concurrency will fill up,
+            // but the breaker + timeouts will already be providing protection against that.
+            // If the isolation strategy is filling up because of a surge of requests, the
+            // rejections will just be a way of shedding load - the breaker and downstream
             // dependency may be just fine, and we want to keep them that way.
 
             // We'll neither mark these as success *nor* failure, since they really didn't
@@ -343,9 +343,12 @@ namespace Hudl.Mjolnir.Command
             // be in a short while since we're queueing these up.
             return IsolationStrategy.Enqueue(() =>
             {
-                // Since we may have been on the thread pool queue for a bit, see if we
+                // Since we may have been on the strategy's queue for a bit, see if we
                 // should have canceled by now.
                 cancellationToken.ThrowIfCancellationRequested();
+
+                // TODO Make sure to test this and throughly understand the behavior.
+                // - What happens when an exception is thrown from any path?
 
                 // These return tasks themselves, hence the .Unwrap() below.
                 return UseCircuitBreakers.Value
@@ -369,6 +372,8 @@ namespace Hudl.Mjolnir.Command
 
                 // Await here so we can catch the Exception and track the state.
                 // I suppose we could do this with a continuation, too. Await's easier.
+                // TODO Come back and reconsider a .ContinueWith() here. If we can use
+                // it, we'll save a bit of state machine generation.
                 result = await ExecuteAsync(cancellationToken);
 
                 CircuitBreaker.MarkSuccess(stopwatch.ElapsedMilliseconds);
@@ -390,7 +395,7 @@ namespace Hudl.Mjolnir.Command
                 return CommandCompletionStatus.Canceled;
             }
 
-            if (e is CircuitBreakerRejectedException || e is IsolationThreadPoolRejectedException)
+            if (e is CircuitBreakerRejectedException || e is IsolationStrategyRejectedException)
             {
                 return CommandCompletionStatus.Rejected;
             }

--- a/Hudl.Mjolnir/Command/Command.cs
+++ b/Hudl.Mjolnir/Command/Command.cs
@@ -8,8 +8,8 @@ using Hudl.Common.Extensions;
 using Hudl.Config;
 using Hudl.Mjolnir.Breaker;
 using Hudl.Mjolnir.External;
+using Hudl.Mjolnir.Isolation;
 using Hudl.Mjolnir.Key;
-using Hudl.Mjolnir.ThreadPool;
 using log4net;
 
 namespace Hudl.Mjolnir.Command

--- a/Hudl.Mjolnir/Command/CommandContext.cs
+++ b/Hudl.Mjolnir/Command/CommandContext.cs
@@ -3,9 +3,9 @@ using System.Collections.Concurrent;
 using Hudl.Config;
 using Hudl.Mjolnir.Breaker;
 using Hudl.Mjolnir.External;
+using Hudl.Mjolnir.Isolation;
 using Hudl.Mjolnir.Key;
 using Hudl.Mjolnir.Metrics;
-using Hudl.Mjolnir.ThreadPool;
 using Hudl.Mjolnir.Util;
 
 namespace Hudl.Mjolnir.Command

--- a/Hudl.Mjolnir/Command/CommandContext.cs
+++ b/Hudl.Mjolnir/Command/CommandContext.cs
@@ -23,7 +23,7 @@ namespace Hudl.Mjolnir.Command
 
         private readonly ConcurrentDictionary<GroupKey, Lazy<ICircuitBreaker>> _circuitBreakers = new ConcurrentDictionary<GroupKey, Lazy<ICircuitBreaker>>();
         private readonly ConcurrentDictionary<GroupKey, Lazy<ICommandMetrics>> _metrics = new ConcurrentDictionary<GroupKey, Lazy<ICommandMetrics>>();
-        private readonly ConcurrentDictionary<GroupKey, Lazy<IIsolationThreadPool>> _pools = new ConcurrentDictionary<GroupKey, Lazy<IIsolationThreadPool>>();
+        private readonly ConcurrentDictionary<GroupKey, Lazy<IQueuedIsolationStrategy>> _pools = new ConcurrentDictionary<GroupKey, Lazy<IQueuedIsolationStrategy>>();
         private readonly ConcurrentDictionary<GroupKey, Lazy<IIsolationSemaphore>> _fallbackSemaphores = new ConcurrentDictionary<GroupKey, Lazy<IIsolationSemaphore>>();
 
         private IStats _stats = new IgnoringStats();
@@ -87,7 +87,7 @@ namespace Hudl.Mjolnir.Command
                     Stats));
         }
 
-        internal static IIsolationThreadPool GetThreadPool(GroupKey key)
+        internal static IQueuedIsolationStrategy GetThreadPool(GroupKey key)
         {
             if (key == null)
             {

--- a/Hudl.Mjolnir/Command/CommandContext.cs
+++ b/Hudl.Mjolnir/Command/CommandContext.cs
@@ -11,8 +11,8 @@ using Hudl.Mjolnir.Util;
 namespace Hudl.Mjolnir.Command
 {
     /// <summary>
-    /// Manages all of Mjolnir's pools, breakers, and other state. Also handles
-    /// dependency injection for replaceable components (stats, config, etc.).
+    /// Manages all of Mjolnir's isolation strategies, breakers, and other state.
+    /// Also handles dependency injection for replaceable components (stats, config, etc.).
     /// 
     /// Client code typically doesn't interact with CommandContext other than
     /// to inject dependencies.
@@ -23,7 +23,7 @@ namespace Hudl.Mjolnir.Command
 
         private readonly ConcurrentDictionary<GroupKey, Lazy<ICircuitBreaker>> _circuitBreakers = new ConcurrentDictionary<GroupKey, Lazy<ICircuitBreaker>>();
         private readonly ConcurrentDictionary<GroupKey, Lazy<ICommandMetrics>> _metrics = new ConcurrentDictionary<GroupKey, Lazy<ICommandMetrics>>();
-        private readonly ConcurrentDictionary<GroupKey, Lazy<IQueuedIsolationStrategy>> _pools = new ConcurrentDictionary<GroupKey, Lazy<IQueuedIsolationStrategy>>();
+        private readonly ConcurrentDictionary<GroupKey, Lazy<IQueuedIsolationStrategy>> _isolationStrategy = new ConcurrentDictionary<GroupKey, Lazy<IQueuedIsolationStrategy>>();
         private readonly ConcurrentDictionary<GroupKey, Lazy<IIsolationSemaphore>> _fallbackSemaphores = new ConcurrentDictionary<GroupKey, Lazy<IIsolationSemaphore>>();
 
         private IStats _stats = new IgnoringStats();
@@ -87,16 +87,16 @@ namespace Hudl.Mjolnir.Command
                     Stats));
         }
 
-        internal static IQueuedIsolationStrategy GetThreadPool(GroupKey key)
+        internal static IQueuedIsolationStrategy GetIsolationStrategy(GroupKey key)
         {
             if (key == null)
             {
                 throw new ArgumentNullException("key");
             }
 
-            return Instance._pools.GetOrAddSafe(key, k =>
+            return Instance._isolationStrategy.GetOrAddSafe(key, k =>
                 new TaskSchedulerQueuedIsolationStrategy(
-                    new ConfigurableValue<int>("mjolnir.pools." + key + ".threadCount", 10),
+                    new ConfigurableValue<int>("mjolnir.pools." + key + ".threadCount", 10), // TODO "threadCount" and "pools" are too specific; change while maintaining backwards compatibility
                     new ConfigurableValue<int>("mjolnir.pools." + key + ".queueLength", 10)));
         }
 
@@ -109,8 +109,8 @@ namespace Hudl.Mjolnir.Command
 
             return Instance._fallbackSemaphores.GetOrAddSafe(key, k =>
             {
-                // For now, the default here is 5x the default pool threadCount, with the presumption that
-                // several commands may using the same pool, and we should therefore try to allow for a bit
+                // For now, the default here is 5x the default isolation concurrency, with the presumption that
+                // several commands may using the same isolation group, and we should therefore try to allow for a bit
                 // more concurrent fallback execution.
                 var maxConcurrent = new ConfigurableValue<int>("mjolnir.fallback." + key + ".maxConcurrent", 50);
                 return new SemaphoreSlimIsolationSemaphore(key, maxConcurrent, Stats);

--- a/Hudl.Mjolnir/Command/CommandContext.cs
+++ b/Hudl.Mjolnir/Command/CommandContext.cs
@@ -95,7 +95,7 @@ namespace Hudl.Mjolnir.Command
             }
 
             return Instance._isolationStrategy.GetOrAddSafe(key, k =>
-                new TaskSchedulerQueuedIsolationStrategy(
+                new QueuedTaskSchedulerIsolationStrategy(
                     new ConfigurableValue<int>("mjolnir.pools." + key + ".threadCount", 10), // TODO "threadCount" and "pools" are too specific; change while maintaining backwards compatibility
                     new ConfigurableValue<int>("mjolnir.pools." + key + ".queueLength", 10)));
         }

--- a/Hudl.Mjolnir/Command/CommandContext.cs
+++ b/Hudl.Mjolnir/Command/CommandContext.cs
@@ -96,8 +96,10 @@ namespace Hudl.Mjolnir.Command
 
             return Instance._isolationStrategy.GetOrAddSafe(key, k =>
                 new QueuedTaskSchedulerIsolationStrategy(
+                    key,
                     new ConfigurableValue<int>("mjolnir.pools." + key + ".threadCount", 10), // TODO "threadCount" and "pools" are too specific; change while maintaining backwards compatibility
-                    new ConfigurableValue<int>("mjolnir.pools." + key + ".queueLength", 10)));
+                    new ConfigurableValue<int>("mjolnir.pools." + key + ".queueLength", 10),
+                    Stats));
         }
 
         internal static IIsolationSemaphore GetFallbackSemaphore(GroupKey key)

--- a/Hudl.Mjolnir/Command/CommandContext.cs
+++ b/Hudl.Mjolnir/Command/CommandContext.cs
@@ -95,11 +95,9 @@ namespace Hudl.Mjolnir.Command
             }
 
             return Instance._pools.GetOrAddSafe(key, k =>
-                new StpIsolationThreadPool(
-                    key,
+                new TaskSchedulerQueuedIsolationStrategy(
                     new ConfigurableValue<int>("mjolnir.pools." + key + ".threadCount", 10),
-                    new ConfigurableValue<int>("mjolnir.pools." + key + ".queueLength", 10),
-                    Stats));
+                    new ConfigurableValue<int>("mjolnir.pools." + key + ".queueLength", 10)));
         }
 
         internal static IIsolationSemaphore GetFallbackSemaphore(GroupKey key)

--- a/Hudl.Mjolnir/Hudl.Mjolnir.csproj
+++ b/Hudl.Mjolnir/Hudl.Mjolnir.csproj
@@ -93,7 +93,7 @@
     <Compile Include="Command\CommandCompletionStatus.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Isolation\IIsolationSemaphore.cs" />
-    <Compile Include="Isolation\IIsolationThreadPool.cs" />
+    <Compile Include="Isolation\IQueuedIsolationStrategy.cs" />
     <Compile Include="Isolation\IsolationThreadPoolException.cs" />
     <Compile Include="Isolation\IWorkItem.cs" />
     <Compile Include="Isolation\SemaphoreSlimIsolationSemaphore.cs" />

--- a/Hudl.Mjolnir/Hudl.Mjolnir.csproj
+++ b/Hudl.Mjolnir/Hudl.Mjolnir.csproj
@@ -92,13 +92,13 @@
     <Compile Include="Command\FallbackStatus.cs" />
     <Compile Include="Command\CommandCompletionStatus.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="ThreadPool\IIsolationSemaphore.cs" />
-    <Compile Include="ThreadPool\IIsolationThreadPool.cs" />
-    <Compile Include="ThreadPool\IsolationThreadPoolException.cs" />
-    <Compile Include="ThreadPool\IWorkItem.cs" />
-    <Compile Include="ThreadPool\SemaphoreSlimIsolationSemaphore.cs" />
-    <Compile Include="ThreadPool\StpIsolationThreadPool.cs" />
-    <Compile Include="ThreadPool\StpWorkItem.cs" />
+    <Compile Include="Isolation\IIsolationSemaphore.cs" />
+    <Compile Include="Isolation\IIsolationThreadPool.cs" />
+    <Compile Include="Isolation\IsolationThreadPoolException.cs" />
+    <Compile Include="Isolation\IWorkItem.cs" />
+    <Compile Include="Isolation\SemaphoreSlimIsolationSemaphore.cs" />
+    <Compile Include="Isolation\StpIsolationThreadPool.cs" />
+    <Compile Include="Isolation\StpWorkItem.cs" />
     <Compile Include="Util\ConcurrentDictionaryExtensions.cs" />
     <Compile Include="Util\GaugeTimer.cs" />
   </ItemGroup>

--- a/Hudl.Mjolnir/Hudl.Mjolnir.csproj
+++ b/Hudl.Mjolnir/Hudl.Mjolnir.csproj
@@ -80,6 +80,10 @@
     <Compile Include="Command\VoidResult.cs" />
     <Compile Include="External\IgnoringStats.cs" />
     <Compile Include="External\IStats.cs" />
+    <Compile Include="Isolation\IIsolationThreadPool.cs" />
+    <Compile Include="Isolation\IQueuedIsolationStrategy.cs" />
+    <Compile Include="Isolation\LimitedConcurrencyTaskScheduler.cs" />
+    <Compile Include="Isolation\TaskSchedulerQueuedIsolationStrategy.cs" />
     <Compile Include="Key\GroupKey.cs" />
     <Compile Include="Metrics\CounterMetric.cs" />
     <Compile Include="Metrics\ICommandMetrics.cs" />
@@ -93,7 +97,6 @@
     <Compile Include="Command\CommandCompletionStatus.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Isolation\IIsolationSemaphore.cs" />
-    <Compile Include="Isolation\IQueuedIsolationStrategy.cs" />
     <Compile Include="Isolation\IsolationThreadPoolException.cs" />
     <Compile Include="Isolation\IWorkItem.cs" />
     <Compile Include="Isolation\SemaphoreSlimIsolationSemaphore.cs" />

--- a/Hudl.Mjolnir/Hudl.Mjolnir.csproj
+++ b/Hudl.Mjolnir/Hudl.Mjolnir.csproj
@@ -83,7 +83,7 @@
     <Compile Include="Isolation\IIsolationThreadPool.cs" />
     <Compile Include="Isolation\IQueuedIsolationStrategy.cs" />
     <Compile Include="Isolation\LimitedConcurrencyTaskScheduler.cs" />
-    <Compile Include="Isolation\TaskSchedulerQueuedIsolationStrategy.cs" />
+    <Compile Include="Isolation\QueuedTaskSchedulerIsolationStrategy.cs" />
     <Compile Include="Key\GroupKey.cs" />
     <Compile Include="Metrics\CounterMetric.cs" />
     <Compile Include="Metrics\ICommandMetrics.cs" />

--- a/Hudl.Mjolnir/Isolation/IIsolationSemaphore.cs
+++ b/Hudl.Mjolnir/Isolation/IIsolationSemaphore.cs
@@ -1,4 +1,4 @@
-﻿namespace Hudl.Mjolnir.ThreadPool
+﻿namespace Hudl.Mjolnir.Isolation
 {
     internal interface IIsolationSemaphore
     {

--- a/Hudl.Mjolnir/Isolation/IIsolationThreadPool.cs
+++ b/Hudl.Mjolnir/Isolation/IIsolationThreadPool.cs
@@ -1,0 +1,29 @@
+﻿namespace Hudl.Mjolnir.Isolation
+{
+    /// <summary>
+    /// A thread pool whose purposes is to isolate a group of operations from the rest of the system.
+    /// 
+    /// Implementations should allow clients to try to queue items for processing, but should be
+    /// proactive about disallowing operations when the pool (and its queue) are at capacity.
+    /// 
+    /// Operations within the system should be partitioned into logical groups (for example, based on
+    /// downstream dependencies, or a common remote endpoint). Each group should use its own
+    /// IIsolationThreadPool; if one group begins to experience latency, back up, and reach capacity,
+    /// further operations in that group should be rejected instead of blocking more resources
+    /// (i.e. threads) that could instead be used for operations that aren't in the group and are
+    /// successfully completing.
+    /// </summary>
+    internal interface IIsolationThreadPool
+    {
+        void Start();
+
+        /// <summary>
+        /// Queues the function for execution on the pool. If the pool and queue (if available) are at
+        /// capacity, may throw an <see cref="IsolationThreadPoolRejectedException">IsolationThreadPoolRejectedException</see>.
+        /// </summary>
+        /// <typeparam name="TResult">The type of result that will be returned from the work item.</typeparam>
+        /// <param name="func">Function to execute on the pool thread.</param>
+        /// <returns>A work item whose <code>Get()</code> method will return the <code>TResult</code>.</returns>
+        IWorkItem<TResult> Enqueue<TResult>(System.Func<TResult> func);
+    }
+}

--- a/Hudl.Mjolnir/Isolation/IIsolationThreadPool.cs
+++ b/Hudl.Mjolnir/Isolation/IIsolationThreadPool.cs
@@ -1,4 +1,4 @@
-﻿namespace Hudl.Mjolnir.ThreadPool
+﻿namespace Hudl.Mjolnir.Isolation
 {
     /// <summary>
     /// A thread pool whose purposes is to isolate a group of operations from the rest of the system.

--- a/Hudl.Mjolnir/Isolation/IQueuedIsolationStrategy.cs
+++ b/Hudl.Mjolnir/Isolation/IQueuedIsolationStrategy.cs
@@ -1,32 +1,11 @@
-﻿namespace Hudl.Mjolnir.Isolation
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Hudl.Mjolnir.Isolation
 {
-    /// <summary>
-    /// Isolate a group of operations from the rest of the system, queuing them for work in some
-    /// limited-resource manner (e.g. thread pool, counting semaphore).
-    /// 
-    /// Implementations should allow clients to try to queue items for processing, but should be
-    /// proactive about disallowing operations when the pool (and its queue) are at capacity.
-    /// 
-    /// Operations within the system should be partitioned into logical groups (for example, based on
-    /// downstream dependencies, or a common remote endpoint). Each group should use its own
-    /// IQueuedIsolationStrategy; if one group begins to experience latency, back up, and reach capacity,
-    /// further operations in that group should be rejected instead of blocking more resources
-    /// (i.e. threads) that could instead be used for operations that aren't in the group and are
-    /// successfully completing.
-    /// </summary>
     internal interface IQueuedIsolationStrategy
     {
-        // TODO Less necessary if we don't use a thread pool, but can be a no-op.
-        //   - Possibly split this into a separate interface and/or push it to a factory.
-        void Start();
-
-        /// <summary>
-        /// Queues an operation for execution. If the queue (if available) and concurrency-limiting mechanism are at
-        /// capacity, may throw an <see cref="IsolationStrategyRejectedException">IsolationStrategyRejectedException</see>.
-        /// </summary>
-        /// <typeparam name="TResult">The type of result that will be returned from the work item.</typeparam>
-        /// <param name="func">Operation to execute when the strategy implementation dequeues it.</param>
-        /// <returns>A work item whose <code>Get()</code> method will return the <code>TResult</code>.</returns>
-        IWorkItem<TResult> Enqueue<TResult>(System.Func<TResult> func);
+        Task<TResult> Enqueue<TResult>(Func<TResult> func, CancellationToken cancellationToken);
     }
 }

--- a/Hudl.Mjolnir/Isolation/IQueuedIsolationStrategy.cs
+++ b/Hudl.Mjolnir/Isolation/IQueuedIsolationStrategy.cs
@@ -6,6 +6,7 @@ namespace Hudl.Mjolnir.Isolation
 {
     internal interface IQueuedIsolationStrategy
     {
+        Task Enqueue(Action action, CancellationToken cancellationToken);
         Task<TResult> Enqueue<TResult>(Func<TResult> func, CancellationToken cancellationToken);
     }
 }

--- a/Hudl.Mjolnir/Isolation/IQueuedIsolationStrategy.cs
+++ b/Hudl.Mjolnir/Isolation/IQueuedIsolationStrategy.cs
@@ -1,28 +1,31 @@
 ﻿namespace Hudl.Mjolnir.Isolation
 {
     /// <summary>
-    /// A thread pool whose purposes is to isolate a group of operations from the rest of the system.
+    /// Isolate a group of operations from the rest of the system, queuing them for work in some
+    /// limited-resource manner (e.g. thread pool, counting semaphore).
     /// 
     /// Implementations should allow clients to try to queue items for processing, but should be
     /// proactive about disallowing operations when the pool (and its queue) are at capacity.
     /// 
     /// Operations within the system should be partitioned into logical groups (for example, based on
     /// downstream dependencies, or a common remote endpoint). Each group should use its own
-    /// IIsolationThreadPool; if one group begins to experience latency, back up, and reach capacity,
+    /// IQueuedIsolationStrategy; if one group begins to experience latency, back up, and reach capacity,
     /// further operations in that group should be rejected instead of blocking more resources
     /// (i.e. threads) that could instead be used for operations that aren't in the group and are
     /// successfully completing.
     /// </summary>
-    internal interface IIsolationThreadPool
+    internal interface IQueuedIsolationStrategy
     {
+        // TODO Less necessary if we don't use a thread pool, but can be a no-op.
+        //   - Possibly split this into a separate interface and/or push it to a factory.
         void Start();
 
         /// <summary>
-        /// Queues the function for execution on the pool. If the pool and queue (if available) are at
-        /// capacity, may throw an <see cref="IsolationThreadPoolRejectedException">IsolationThreadPoolRejectedException</see>.
+        /// Queues an operation for execution. If the queue (if available) and concurrency-limiting mechanism are at
+        /// capacity, may throw an <see cref="IsolationStrategyRejectedException">IsolationStrategyRejectedException</see>.
         /// </summary>
         /// <typeparam name="TResult">The type of result that will be returned from the work item.</typeparam>
-        /// <param name="func">Function to execute on the pool thread.</param>
+        /// <param name="func">Operation to execute when the strategy implementation dequeues it.</param>
         /// <returns>A work item whose <code>Get()</code> method will return the <code>TResult</code>.</returns>
         IWorkItem<TResult> Enqueue<TResult>(System.Func<TResult> func);
     }

--- a/Hudl.Mjolnir/Isolation/IWorkItem.cs
+++ b/Hudl.Mjolnir/Isolation/IWorkItem.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Threading;
 
-namespace Hudl.Mjolnir.ThreadPool
+namespace Hudl.Mjolnir.Isolation
 {
     internal interface IWorkItem<TResult>
     {

--- a/Hudl.Mjolnir/Isolation/IsolationThreadPoolException.cs
+++ b/Hudl.Mjolnir/Isolation/IsolationThreadPoolException.cs
@@ -11,5 +11,5 @@ namespace Hudl.Mjolnir.Isolation
 
     internal class IsolationThreadPoolRejectedException : IsolationStrategyRejectedException {}
 
-    internal class IsolationSemaphoreRejectedException : IsolationStrategyRejectedException {}
+    internal class TaskSchedulerIsolationRejectionException : IsolationStrategyRejectedException {}
 }

--- a/Hudl.Mjolnir/Isolation/IsolationThreadPoolException.cs
+++ b/Hudl.Mjolnir/Isolation/IsolationThreadPoolException.cs
@@ -11,5 +11,5 @@ namespace Hudl.Mjolnir.Isolation
 
     internal class IsolationThreadPoolRejectedException : IsolationStrategyRejectedException {}
 
-    internal class TaskSchedulerIsolationRejectionException : IsolationStrategyRejectedException {}
+    //internal class TaskSchedulerIsolationRejectionException : IsolationStrategyRejectedException {}
 }

--- a/Hudl.Mjolnir/Isolation/IsolationThreadPoolException.cs
+++ b/Hudl.Mjolnir/Isolation/IsolationThreadPoolException.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Hudl.Mjolnir.ThreadPool
+namespace Hudl.Mjolnir.Isolation
 {
     internal class IsolationThreadPoolException : Exception
     {

--- a/Hudl.Mjolnir/Isolation/IsolationThreadPoolException.cs
+++ b/Hudl.Mjolnir/Isolation/IsolationThreadPoolException.cs
@@ -7,5 +7,9 @@ namespace Hudl.Mjolnir.Isolation
         internal IsolationThreadPoolException(Exception cause) : base(cause.Message, cause) {}
     }
 
-    internal class IsolationThreadPoolRejectedException : Exception {}
+    internal class IsolationStrategyRejectedException : Exception {}
+
+    internal class IsolationThreadPoolRejectedException : IsolationStrategyRejectedException {}
+
+    internal class IsolationSemaphoreRejectedException : IsolationStrategyRejectedException {}
 }

--- a/Hudl.Mjolnir/Isolation/IsolationThreadPoolException.cs
+++ b/Hudl.Mjolnir/Isolation/IsolationThreadPoolException.cs
@@ -7,9 +7,13 @@ namespace Hudl.Mjolnir.Isolation
         internal IsolationThreadPoolException(Exception cause) : base(cause.Message, cause) {}
     }
 
-    internal class IsolationStrategyRejectedException : Exception {}
+    internal class IsolationStrategyRejectedException : Exception
+    {
+        internal IsolationStrategyRejectedException() { }
+        internal IsolationStrategyRejectedException(string message, Exception inner) : base(message, inner) { }
+    }
 
-    internal class IsolationThreadPoolRejectedException : IsolationStrategyRejectedException {}
-
-    //internal class TaskSchedulerIsolationRejectionException : IsolationStrategyRejectedException {}
+    // TODO This is the original class that I'm keeping around for backwards compatibility.
+    // Moving forward, things should create and use IsolationStrategyRejectedExceptions instead.
+    internal class IsolationThreadPoolRejectedException : IsolationStrategyRejectedException { }
 }

--- a/Hudl.Mjolnir/Isolation/LimitedConcurrencyTaskScheduler.cs
+++ b/Hudl.Mjolnir/Isolation/LimitedConcurrencyTaskScheduler.cs
@@ -1,33 +1,43 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Hudl.Mjolnir.Isolation
 {
-    // Straight-up yoinked from http://msdn.microsoft.com/en-us/library/ee789351(v=vs.110).aspx
+    // This implementation is a modified version of one from the Parallel Extensions
+    // Extras project: https://code.msdn.microsoft.com/ParExtSamples
+    // TODO This is MS-LPL, check our license compliance and include MS-LPL if needed.
 
-    // Provides a task scheduler that ensures a maximum concurrency level while  
-    // running on top of the thread pool. 
-    internal class LimitedConcurrencyLevelTaskScheduler : TaskScheduler
+    /// <summary>
+    /// Provides a task scheduler that ensures a maximum concurrency level while
+    /// running on top of the ThreadPool.
+    /// </summary>
+    public class LimitedConcurrencyLevelTaskScheduler : TaskScheduler
     {
-        // Indicates whether the current thread is processing work items.
+        /// <summary>Whether the current thread is processing work items.</summary>
         [ThreadStatic]
         private static bool _currentThreadIsProcessingItems;
-
-        // The list of tasks to be executed  
-        private readonly LinkedList<Task> _tasks = new LinkedList<Task>(); // protected by lock(_tasks) 
-
-        // The maximum concurrency level allowed by this scheduler.  
+        
+        /// <summary>The list of tasks to be executed.</summary>
+        private readonly LinkedList<Task> _tasks = new LinkedList<Task>(); // protected by lock(_tasks)
+        
+        /// <summary>The maximum concurrency level allowed by this scheduler.</summary>
         private readonly int _maxDegreeOfParallelism;
 
-        // The number of items allowed to be queued before we start rejecting them.
+        /// <summary>The number of items allowed to be queued before the scheduler starts rejecting them.</summary>
         private readonly int _maxQueueLength;
 
-        // Indicates whether the scheduler is currently processing work items.  
-        private int _delegatesQueuedOrRunning = 0;
+        /// <summary>Whether the scheduler is currently processing work items.</summary>
+        private int _delegatesQueuedOrRunning = 0; // protected by lock(_tasks)
 
-        // Creates a new instance with the specified degree of parallelism.  
+        /// <summary>
+        /// Initializes an instance of the LimitedConcurrencyLevelTaskScheduler class with the
+        /// specified degree of parallelism.
+        /// </summary>
+        /// <param name="maxDegreeOfParallelism">The maximum degree of parallelism provided by this scheduler.</param>
+        /// <param name="maxQueueLength">The maximum number of tasks to queue up for execution before throwing.</param>
         public LimitedConcurrencyLevelTaskScheduler(int maxDegreeOfParallelism, int maxQueueLength = 10)
         {
             if (maxDegreeOfParallelism < 1) throw new ArgumentOutOfRangeException("maxDegreeOfParallelism");
@@ -36,11 +46,13 @@ namespace Hudl.Mjolnir.Isolation
             _maxQueueLength = maxQueueLength;
         }
 
-        // Queues a task to the scheduler.  
+        /// <summary>Queues a task to the scheduler.</summary>
+        /// <param name="task">The task to be queued.</param>
+        /// <exception cref="QueueLengthExceededException">If the scheduler queue is at its maximum.</exception>
         protected sealed override void QueueTask(Task task)
         {
-            // Add the task to the list of tasks to be processed.  If there aren't enough  
-            // delegates currently queued or running to process tasks, schedule another.  
+            // Add the task to the list of tasks to be processed.  If there aren't enough
+            // delegates currently queued or running to process tasks, schedule another.
             lock (_tasks)
             {
                 if (_tasks.Count >= _maxQueueLength)
@@ -57,24 +69,26 @@ namespace Hudl.Mjolnir.Isolation
             }
         }
 
-        // Inform the ThreadPool that there's work to be executed for this scheduler.  
+        /// <summary>
+        /// Informs the ThreadPool that there's work to be executed for this scheduler.
+        /// </summary>
         private void NotifyThreadPoolOfPendingWork()
         {
             ThreadPool.UnsafeQueueUserWorkItem(_ =>
             {
-                // Note that the current thread is now processing work items. 
+                // Note that the current thread is now processing work items.
                 // This is necessary to enable inlining of tasks into this thread.
                 _currentThreadIsProcessingItems = true;
                 try
                 {
-                    // Process all available items in the queue. 
+                    // Process all available items in the queue.
                     while (true)
                     {
                         Task item;
                         lock (_tasks)
                         {
-                            // When there are no more items to be processed, 
-                            // note that we're done processing, and get out. 
+                            // When there are no more items to be processed,
+                            // note that we're done processing, and get out.
                             if (_tasks.Count == 0)
                             {
                                 --_delegatesQueuedOrRunning;
@@ -86,54 +100,51 @@ namespace Hudl.Mjolnir.Isolation
                             _tasks.RemoveFirst();
                         }
 
-                        // Execute the task we pulled out of the queue 
-                        base.TryExecuteTask(item);
+                        // Execute the task we pulled out of the queue
+                        TryExecuteTask(item);
                     }
                 }
-                // We're done processing items on the current thread 
+                // We're done processing items on the current thread
                 finally { _currentThreadIsProcessingItems = false; }
             }, null);
         }
 
-        // Attempts to execute the specified task on the current thread.  
+        /// <summary>Attempts to execute the specified task on the current thread.</summary>
+        /// <param name="task">The task to be executed.</param>
+        /// <param name="taskWasPreviouslyQueued"></param>
+        /// <returns>Whether the task could be executed on the current thread.</returns>
         protected sealed override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)
         {
-            // If this thread isn't already processing a task, we don't support inlining 
+            // If this thread isn't already processing a task, we don't support inlining
             if (!_currentThreadIsProcessingItems) return false;
 
-            // If the task was previously queued, remove it from the queue 
-            if (taskWasPreviouslyQueued)
-            {
-                // Try to run the task.  
-                if (TryDequeue(task))
-                {
-                    return base.TryExecuteTask(task);
-                }
-                return false;
-            }
-            return base.TryExecuteTask(task);
+            // If the task was previously queued, remove it from the queue
+            if (taskWasPreviouslyQueued) TryDequeue(task);
+
+            // Try to run the task.
+            return TryExecuteTask(task);
         }
 
-        // Attempt to remove a previously scheduled task from the scheduler.  
+        /// <summary>Attempts to remove a previously scheduled task from the scheduler.</summary>
+        /// <param name="task">The task to be removed.</param>
+        /// <returns>Whether the task could be found and removed.</returns>
         protected sealed override bool TryDequeue(Task task)
         {
             lock (_tasks) return _tasks.Remove(task);
         }
 
-        // Gets the maximum concurrency level supported by this scheduler.  
-        public sealed override int MaximumConcurrencyLevel
-        {
-            get { return _maxDegreeOfParallelism; }
-        }
+        /// <summary>Gets the maximum concurrency level supported by this scheduler.</summary>
+        public sealed override int MaximumConcurrencyLevel { get { return _maxDegreeOfParallelism; } }
 
-        // Gets an enumerable of the tasks currently scheduled on this scheduler.  
+        /// <summary>Gets an enumerable of the tasks currently scheduled on this scheduler.</summary>
+        /// <returns>An enumerable of the tasks currently scheduled.</returns>
         protected sealed override IEnumerable<Task> GetScheduledTasks()
         {
-            bool lockTaken = false;
+            var lockTaken = false;
             try
             {
                 Monitor.TryEnter(_tasks, ref lockTaken);
-                if (lockTaken) return _tasks;
+                if (lockTaken) return _tasks.ToArray();
                 else throw new NotSupportedException();
             }
             finally

--- a/Hudl.Mjolnir/Isolation/LimitedConcurrencyTaskScheduler.cs
+++ b/Hudl.Mjolnir/Isolation/LimitedConcurrencyTaskScheduler.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Hudl.Mjolnir.Isolation
+{
+    // Straight-up yoinked from http://msdn.microsoft.com/en-us/library/ee789351(v=vs.110).aspx
+
+    // Provides a task scheduler that ensures a maximum concurrency level while  
+    // running on top of the thread pool. 
+    internal class LimitedConcurrencyLevelTaskScheduler : TaskScheduler
+    {
+        // Indicates whether the current thread is processing work items.
+        [ThreadStatic]
+        private static bool _currentThreadIsProcessingItems;
+
+        // The list of tasks to be executed  
+        private readonly LinkedList<Task> _tasks = new LinkedList<Task>(); // protected by lock(_tasks) 
+
+        // The maximum concurrency level allowed by this scheduler.  
+        private readonly int _maxDegreeOfParallelism;
+
+        // The number of items allowed to be queued before we start rejecting them.
+        private readonly int _maxQueueLength;
+
+        // Indicates whether the scheduler is currently processing work items.  
+        private int _delegatesQueuedOrRunning = 0;
+
+        // Creates a new instance with the specified degree of parallelism.  
+        public LimitedConcurrencyLevelTaskScheduler(int maxDegreeOfParallelism, int maxQueueLength = 10)
+        {
+            if (maxDegreeOfParallelism < 1) throw new ArgumentOutOfRangeException("maxDegreeOfParallelism");
+            if (maxQueueLength < 0) throw new ArgumentOutOfRangeException("maxQueueLength");
+            _maxDegreeOfParallelism = maxDegreeOfParallelism;
+            _maxQueueLength = maxQueueLength;
+        }
+
+        // Queues a task to the scheduler.  
+        protected sealed override void QueueTask(Task task)
+        {
+            // Add the task to the list of tasks to be processed.  If there aren't enough  
+            // delegates currently queued or running to process tasks, schedule another.  
+            lock (_tasks)
+            {
+                if (_tasks.Count >= _maxQueueLength)
+                {
+                    throw new QueueLengthExceededException();
+                }
+
+                _tasks.AddLast(task);
+                if (_delegatesQueuedOrRunning < _maxDegreeOfParallelism)
+                {
+                    ++_delegatesQueuedOrRunning;
+                    NotifyThreadPoolOfPendingWork();
+                }
+            }
+        }
+
+        // Inform the ThreadPool that there's work to be executed for this scheduler.  
+        private void NotifyThreadPoolOfPendingWork()
+        {
+            ThreadPool.UnsafeQueueUserWorkItem(_ =>
+            {
+                // Note that the current thread is now processing work items. 
+                // This is necessary to enable inlining of tasks into this thread.
+                _currentThreadIsProcessingItems = true;
+                try
+                {
+                    // Process all available items in the queue. 
+                    while (true)
+                    {
+                        Task item;
+                        lock (_tasks)
+                        {
+                            // When there are no more items to be processed, 
+                            // note that we're done processing, and get out. 
+                            if (_tasks.Count == 0)
+                            {
+                                --_delegatesQueuedOrRunning;
+                                break;
+                            }
+
+                            // Get the next item from the queue
+                            item = _tasks.First.Value;
+                            _tasks.RemoveFirst();
+                        }
+
+                        // Execute the task we pulled out of the queue 
+                        base.TryExecuteTask(item);
+                    }
+                }
+                // We're done processing items on the current thread 
+                finally { _currentThreadIsProcessingItems = false; }
+            }, null);
+        }
+
+        // Attempts to execute the specified task on the current thread.  
+        protected sealed override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)
+        {
+            // If this thread isn't already processing a task, we don't support inlining 
+            if (!_currentThreadIsProcessingItems) return false;
+
+            // If the task was previously queued, remove it from the queue 
+            if (taskWasPreviouslyQueued)
+            {
+                // Try to run the task.  
+                if (TryDequeue(task))
+                {
+                    return base.TryExecuteTask(task);
+                }
+                return false;
+            }
+            return base.TryExecuteTask(task);
+        }
+
+        // Attempt to remove a previously scheduled task from the scheduler.  
+        protected sealed override bool TryDequeue(Task task)
+        {
+            lock (_tasks) return _tasks.Remove(task);
+        }
+
+        // Gets the maximum concurrency level supported by this scheduler.  
+        public sealed override int MaximumConcurrencyLevel
+        {
+            get { return _maxDegreeOfParallelism; }
+        }
+
+        // Gets an enumerable of the tasks currently scheduled on this scheduler.  
+        protected sealed override IEnumerable<Task> GetScheduledTasks()
+        {
+            bool lockTaken = false;
+            try
+            {
+                Monitor.TryEnter(_tasks, ref lockTaken);
+                if (lockTaken) return _tasks;
+                else throw new NotSupportedException();
+            }
+            finally
+            {
+                if (lockTaken) Monitor.Exit(_tasks);
+            }
+        }
+    }
+
+    internal class QueueLengthExceededException : Exception { }
+}

--- a/Hudl.Mjolnir/Isolation/QueuedTaskSchedulerIsolationStrategy.cs
+++ b/Hudl.Mjolnir/Isolation/QueuedTaskSchedulerIsolationStrategy.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Hudl.Config;

--- a/Hudl.Mjolnir/Isolation/QueuedTaskSchedulerIsolationStrategy.cs
+++ b/Hudl.Mjolnir/Isolation/QueuedTaskSchedulerIsolationStrategy.cs
@@ -9,12 +9,12 @@ namespace Hudl.Mjolnir.Isolation
     /// <summary>
     /// Isolates operations by using a concurrency-limiting, queue-driven TaskScheduler.
     /// </summary>
-    internal class TaskSchedulerQueuedIsolationStrategy : IQueuedIsolationStrategy
+    internal class QueuedTaskSchedulerIsolationStrategy : IQueuedIsolationStrategy
     {
         // Custom TaskFactory that handles concurrency and task queueing.
         private readonly TaskFactory _factory;
 
-        internal TaskSchedulerQueuedIsolationStrategy(IConfigurableValue<int> maxConcurrency, IConfigurableValue<int> maxQueueLength)
+        internal QueuedTaskSchedulerIsolationStrategy(IConfigurableValue<int> maxConcurrency, IConfigurableValue<int> maxQueueLength)
         {
             var scheduler = new LimitedConcurrencyLevelTaskScheduler(maxConcurrency, maxQueueLength);
             _factory = new TaskFactory(scheduler);
@@ -33,8 +33,8 @@ namespace Hudl.Mjolnir.Isolation
                 // Hide the TaskScheduler implementation by wrapping with an
                 // isolation-specific exception.
                 ExceptionDispatchInfo.Capture(e).Throw();
-                throw; // Should never get here.
             }
+            throw new InvalidOperationException("Unexpectedly reached the end of Enqueue<TResult>() without returning or throwing");
         }
     }
 }

--- a/Hudl.Mjolnir/Isolation/QueuedTaskSchedulerIsolationStrategy.cs
+++ b/Hudl.Mjolnir/Isolation/QueuedTaskSchedulerIsolationStrategy.cs
@@ -16,30 +16,53 @@ namespace Hudl.Mjolnir.Isolation
         internal QueuedTaskSchedulerIsolationStrategy(IConfigurableValue<int> maxConcurrency, IConfigurableValue<int> maxQueueLength)
         {
             var scheduler = new LimitedConcurrencyLevelTaskScheduler(maxConcurrency, maxQueueLength);
-            _factory = new TaskFactory(scheduler);
+
+            // Hide the scheduler we're using here (using TaskCreationOptions.HideScheduler)
+            // from any new Tasks spawned by the actions we Enqueue(). We'll just let them
+            // use the default scheduler. If they turn out to be other commands, they'll get
+            // isolated when they're executed by their own command.
+            _factory = new TaskFactory(CancellationToken.None, TaskCreationOptions.HideScheduler, TaskContinuationOptions.None, scheduler);
+        }
+
+        public Task Enqueue(Action action, CancellationToken cancellationToken)
+        {
+            try
+            {
+                return _factory.StartNew(action, cancellationToken);
+            }
+            catch (TaskSchedulerException e)
+            {
+                HandleTaskSchedulerException(e);
+                throw;
+            }
         }
 
         public Task<TResult> Enqueue<TResult>(Func<TResult> func, CancellationToken cancellationToken)
         {
             try
             {
-                // Should throw if the scheduler is at max concurrency and
-                // its queue is also at capacity.
                 return _factory.StartNew(func, cancellationToken);
             }
             catch (TaskSchedulerException e)
             {
-                if (e.InnerException is QueueLengthExceededException)
-                {
-                    var f = new IsolationStrategyRejectedException("TaskScheduler is at maximum concurrency and queue size", e);
-                    foreach (var key in e.InnerException.Data.Keys)
-                    {
-                        f.Data[key] = e.InnerException.Data[key];
-                    }
-                    throw f;
-                }
-
+                HandleTaskSchedulerException(e);
                 throw;
+            }
+        }
+
+        private static void HandleTaskSchedulerException(TaskSchedulerException e)
+        {
+            // A QueueLengthExceededException is the only special case - it means
+            // that we're hitting our limits and should reject the operation.
+            // Wrap it in an isolation-specific exception so callers can react.
+            if (e.InnerException is QueueLengthExceededException)
+            {
+                var f = new IsolationStrategyRejectedException("TaskScheduler is at maximum concurrency and queue size", e);
+                foreach (var key in e.InnerException.Data.Keys)
+                {
+                    f.Data[key] = e.InnerException.Data[key];
+                }
+                throw f;
             }
         }
     }

--- a/Hudl.Mjolnir/Isolation/QueuedTaskSchedulerIsolationStrategy.cs
+++ b/Hudl.Mjolnir/Isolation/QueuedTaskSchedulerIsolationStrategy.cs
@@ -1,7 +1,11 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Hudl.Config;
+using Hudl.Mjolnir.External;
+using Hudl.Mjolnir.Key;
+using Hudl.Mjolnir.Util;
 
 namespace Hudl.Mjolnir.Isolation
 {
@@ -10,11 +14,16 @@ namespace Hudl.Mjolnir.Isolation
     /// </summary>
     internal class QueuedTaskSchedulerIsolationStrategy : IQueuedIsolationStrategy
     {
+        private readonly GroupKey _key;
+        private readonly IStats _stats;
+
         // Custom TaskFactory that handles concurrency and task queueing.
         private readonly TaskFactory _factory;
 
-        internal QueuedTaskSchedulerIsolationStrategy(IConfigurableValue<int> maxConcurrency, IConfigurableValue<int> maxQueueLength)
+        internal QueuedTaskSchedulerIsolationStrategy(GroupKey key, IConfigurableValue<int> maxConcurrency, IConfigurableValue<int> maxQueueLength, IStats stats)
         {
+            _key = key;
+            _stats = stats;
             var scheduler = new LimitedConcurrencyLevelTaskScheduler(maxConcurrency, maxQueueLength);
 
             // Hide the scheduler we're using here (using TaskCreationOptions.HideScheduler)
@@ -24,45 +33,70 @@ namespace Hudl.Mjolnir.Isolation
             _factory = new TaskFactory(CancellationToken.None, TaskCreationOptions.HideScheduler, TaskContinuationOptions.None, scheduler);
         }
 
+        private string StatsPrefix
+        {
+            get { return "mjolnir pool " + _key; }
+        }
+
         public Task Enqueue(Action action, CancellationToken cancellationToken)
         {
+            var stopwatch = Stopwatch.StartNew();
+            var state = "Enqueued";
             try
             {
                 return _factory.StartNew(action, cancellationToken);
             }
             catch (TaskSchedulerException e)
             {
-                HandleTaskSchedulerException(e);
+                // A QueueLengthExceededException is the only special case - it means
+                // that we're hitting our limits and should reject the operation.
+                // Wrap it in an isolation-specific exception so callers can react.
+                if (e.InnerException is QueueLengthExceededException)
+                {
+                    state = "Rejected";
+                    var f = new IsolationStrategyRejectedException("TaskScheduler is at maximum concurrency and queue size", e);
+                    foreach (var key in e.InnerException.Data.Keys)
+                    {
+                        f.Data[key] = e.InnerException.Data[key];
+                    }
+                    throw f;
+                }
                 throw;
+            }
+            finally
+            {
+                _stats.Elapsed(StatsPrefix + " Enqueue", state, stopwatch.Elapsed);
             }
         }
 
         public Task<TResult> Enqueue<TResult>(Func<TResult> func, CancellationToken cancellationToken)
         {
+            var stopwatch = Stopwatch.StartNew();
+            var state = "Enqueued";
             try
             {
                 return _factory.StartNew(func, cancellationToken);
             }
             catch (TaskSchedulerException e)
             {
-                HandleTaskSchedulerException(e);
+                // A QueueLengthExceededException is the only special case - it means
+                // that we're hitting our limits and should reject the operation.
+                // Wrap it in an isolation-specific exception so callers can react.
+                if (e.InnerException is QueueLengthExceededException)
+                {
+                    state = "Rejected";
+                    var f = new IsolationStrategyRejectedException("TaskScheduler is at maximum concurrency and queue size", e);
+                    foreach (var key in e.InnerException.Data.Keys)
+                    {
+                        f.Data[key] = e.InnerException.Data[key];
+                    }
+                    throw f;
+                }
                 throw;
             }
-        }
-
-        private static void HandleTaskSchedulerException(TaskSchedulerException e)
-        {
-            // A QueueLengthExceededException is the only special case - it means
-            // that we're hitting our limits and should reject the operation.
-            // Wrap it in an isolation-specific exception so callers can react.
-            if (e.InnerException is QueueLengthExceededException)
+            finally
             {
-                var f = new IsolationStrategyRejectedException("TaskScheduler is at maximum concurrency and queue size", e);
-                foreach (var key in e.InnerException.Data.Keys)
-                {
-                    f.Data[key] = e.InnerException.Data[key];
-                }
-                throw f;
+                _stats.Elapsed(StatsPrefix + " Enqueue", state, stopwatch.Elapsed);
             }
         }
     }

--- a/Hudl.Mjolnir/Isolation/SemaphoreSlimIsolationSemaphore.cs
+++ b/Hudl.Mjolnir/Isolation/SemaphoreSlimIsolationSemaphore.cs
@@ -5,7 +5,7 @@ using Hudl.Mjolnir.External;
 using Hudl.Mjolnir.Key;
 using Hudl.Mjolnir.Util;
 
-namespace Hudl.Mjolnir.ThreadPool
+namespace Hudl.Mjolnir.Isolation
 {
     internal class SemaphoreSlimIsolationSemaphore : IIsolationSemaphore
     {

--- a/Hudl.Mjolnir/Isolation/StpIsolationThreadPool.cs
+++ b/Hudl.Mjolnir/Isolation/StpIsolationThreadPool.cs
@@ -9,9 +9,9 @@ using Hudl.Mjolnir.Util;
 namespace Hudl.Mjolnir.Isolation
 {
     /// <summary>
-    /// IIsolationThreadPool that uses a backing SmartThreadPool.
+    /// IQueuedIsolationStrategy that uses a backing SmartThreadPool.
     /// </summary>
-    internal class StpIsolationThreadPool : IIsolationThreadPool
+    internal class StpIsolationThreadPool : IQueuedIsolationStrategy
     {
         private readonly GroupKey _key;
         private readonly SmartThreadPool _pool;

--- a/Hudl.Mjolnir/Isolation/StpIsolationThreadPool.cs
+++ b/Hudl.Mjolnir/Isolation/StpIsolationThreadPool.cs
@@ -9,9 +9,9 @@ using Hudl.Mjolnir.Util;
 namespace Hudl.Mjolnir.Isolation
 {
     /// <summary>
-    /// IQueuedIsolationStrategy that uses a backing SmartThreadPool.
+    /// IIsolationThreadPool that uses a backing SmartThreadPool.
     /// </summary>
-    internal class StpIsolationThreadPool : IQueuedIsolationStrategy
+    internal class StpIsolationThreadPool : IIsolationThreadPool
     {
         private readonly GroupKey _key;
         private readonly SmartThreadPool _pool;

--- a/Hudl.Mjolnir/Isolation/StpIsolationThreadPool.cs
+++ b/Hudl.Mjolnir/Isolation/StpIsolationThreadPool.cs
@@ -6,7 +6,7 @@ using Hudl.Mjolnir.External;
 using Hudl.Mjolnir.Key;
 using Hudl.Mjolnir.Util;
 
-namespace Hudl.Mjolnir.ThreadPool
+namespace Hudl.Mjolnir.Isolation
 {
     /// <summary>
     /// IIsolationThreadPool that uses a backing SmartThreadPool.

--- a/Hudl.Mjolnir/Isolation/StpWorkItem.cs
+++ b/Hudl.Mjolnir/Isolation/StpWorkItem.cs
@@ -1,10 +1,9 @@
 ﻿using System;
-using System.Diagnostics.Contracts;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using Amib.Threading;
 
-namespace Hudl.Mjolnir.ThreadPool
+namespace Hudl.Mjolnir.Isolation
 {
     /// <summary>
     /// WorkItem implementation for SmartThreadPool work items.

--- a/Hudl.Mjolnir/Isolation/TaskSchedulerQueuedIsolationStrategy.cs
+++ b/Hudl.Mjolnir/Isolation/TaskSchedulerQueuedIsolationStrategy.cs
@@ -1,25 +1,40 @@
 ﻿using System;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Hudl.Config;
 
 namespace Hudl.Mjolnir.Isolation
 {
+    /// <summary>
+    /// Isolates operations by using a concurrency-limiting TaskScheduler.
+    /// </summary>
     internal class TaskSchedulerQueuedIsolationStrategy : IQueuedIsolationStrategy
     {
+        // Custom TaskFactory that handles concurrency and task queueing.
         private readonly TaskFactory _factory;
 
         internal TaskSchedulerQueuedIsolationStrategy(IConfigurableValue<int> maxConcurrency, IConfigurableValue<int> maxQueueLength)
         {
             var scheduler = new LimitedConcurrencyLevelTaskScheduler(maxConcurrency.Value, maxQueueLength.Value);
-            var factory = new TaskFactory(scheduler);
-
-            _factory = factory;
+            _factory = new TaskFactory(scheduler);
         }
 
         public Task<TResult> Enqueue<TResult>(Func<TResult> func, CancellationToken cancellationToken)
         {
-            return _factory.StartNew(func, cancellationToken);
+            try
+            {
+                // Should throw if the scheduler is at max concurrency and
+                // its queue is also at capacity.
+                return _factory.StartNew(func, cancellationToken);
+            }
+            catch (QueueLengthExceededException e)
+            {
+                // Hide the TaskScheduler implementation by wrapping with an
+                // isolation-specific exception.
+                ExceptionDispatchInfo.Capture(e).Throw();
+                throw; // Should never get here.
+            }
         }
     }
 }

--- a/Hudl.Mjolnir/Isolation/TaskSchedulerQueuedIsolationStrategy.cs
+++ b/Hudl.Mjolnir/Isolation/TaskSchedulerQueuedIsolationStrategy.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Hudl.Config;
+
+namespace Hudl.Mjolnir.Isolation
+{
+    internal class TaskSchedulerQueuedIsolationStrategy : IQueuedIsolationStrategy
+    {
+        private readonly TaskFactory _factory;
+
+        internal TaskSchedulerQueuedIsolationStrategy(IConfigurableValue<int> maxConcurrency, IConfigurableValue<int> maxQueueLength)
+        {
+            var scheduler = new LimitedConcurrencyLevelTaskScheduler(maxConcurrency.Value, maxQueueLength.Value);
+            var factory = new TaskFactory(scheduler);
+
+            _factory = factory;
+        }
+
+        public Task<TResult> Enqueue<TResult>(Func<TResult> func, CancellationToken cancellationToken)
+        {
+            return _factory.StartNew(func, cancellationToken);
+        }
+    }
+}

--- a/Hudl.Mjolnir/Isolation/TaskSchedulerQueuedIsolationStrategy.cs
+++ b/Hudl.Mjolnir/Isolation/TaskSchedulerQueuedIsolationStrategy.cs
@@ -7,7 +7,7 @@ using Hudl.Config;
 namespace Hudl.Mjolnir.Isolation
 {
     /// <summary>
-    /// Isolates operations by using a concurrency-limiting TaskScheduler.
+    /// Isolates operations by using a concurrency-limiting, queue-driven TaskScheduler.
     /// </summary>
     internal class TaskSchedulerQueuedIsolationStrategy : IQueuedIsolationStrategy
     {
@@ -16,7 +16,7 @@ namespace Hudl.Mjolnir.Isolation
 
         internal TaskSchedulerQueuedIsolationStrategy(IConfigurableValue<int> maxConcurrency, IConfigurableValue<int> maxQueueLength)
         {
-            var scheduler = new LimitedConcurrencyLevelTaskScheduler(maxConcurrency.Value, maxQueueLength.Value);
+            var scheduler = new LimitedConcurrencyLevelTaskScheduler(maxConcurrency, maxQueueLength);
             _factory = new TaskFactory(scheduler);
         }
 


### PR DESCRIPTION
Getting this out there for some early review. Quite unfinished, but will pick it back up in a couple weeks.

The problem: Mjolnir's been using thread pools to isolate calls by limiting concurrency. This isn't a bad approach, but has its drawbacks:
- Thread pools are kind of expensive (See #19)
- The implementation we use (SmartThreadPool) is terrible about preserving context
- SmartThreadPool hasn't accepted my PR to support bounded queues, which means we have to deliver the DLL manually (See #16).
- SmartThreadPool doesn't have great support for `Task`s, which resulted in some wrapping and `.Get()` blocking calls.

I originally wanted to replace our thread pools with a queue+semaphore, but having researched a bit more, I think custom TaskSchedulers would be way better. In fact, there's [an MSDN example](http://msdn.microsoft.com/en-us/library/ee789351(v=vs.110).aspx) of a concurrency-limiting TaskScheduler that I just yoinked into this PR (and modified) to prove the concept.

Since the `TaskScheduler`'s going to be really good with `Task`s, I'm planning on just removing most of the thread pool related bits and some of the abstractions (e.g. `IWorkItem`). We can add them back in if we need to later.

Still a lot to do here. Tests are passing, but I need some specific tests for the scheduler and some more integration-like tests to check that Exceptions get thrown and caught from the right place when we reject calls or when the isolated operation throws an exception.