### PR TITLE
Ability to ignore exception types when counting breaker errors

### DIFF
--- a/Hudl.Mjolnir/Command/Command.cs
+++ b/Hudl.Mjolnir/Command/Command.cs
@@ -380,9 +380,17 @@ namespace Hudl.Mjolnir.Command
                 CircuitBreaker.MarkSuccess(stopwatch.ElapsedMilliseconds);
                 CircuitBreaker.Metrics.MarkCommandSuccess();
             }
-            catch (Exception)
+            catch (Exception e)
             {
-                CircuitBreaker.Metrics.MarkCommandFailure();
+                if (CommandContext.IsExceptionIgnored(e.GetType()))
+                {
+                    CircuitBreaker.Metrics.MarkCommandSuccess();
+                }
+                else
+                {
+                    CircuitBreaker.Metrics.MarkCommandFailure();
+                }
+                
                 throw;
             }
 

--- a/Hudl.Mjolnir/Command/CommandContext.cs
+++ b/Hudl.Mjolnir/Command/CommandContext.cs
@@ -60,13 +60,6 @@ namespace Hudl.Mjolnir.Command
         private readonly ConcurrentDictionary<GroupKey, Lazy<IIsolationThreadPool>> _pools = new ConcurrentDictionary<GroupKey, Lazy<IIsolationThreadPool>>();
         private readonly ConcurrentDictionary<GroupKey, Lazy<IIsolationSemaphore>> _fallbackSemaphores = new ConcurrentDictionary<GroupKey, Lazy<IIsolationSemaphore>>();
 
-        // These exception types won't count toward breakers tripping or other error counters.
-        // Useful for things like validation, where the system isn't having any problems and the
-        // caller needs to validate before invoking. This list is most applicable when using
-        // [Command] attributes, since extending Command offers the ability to catch these types
-        // specifically within Execute() - though there may still be some benefit in extended
-        // Commands for validation-like situations where throwing is still desired.
-        //
         // This is a Dictionary only because there's no great concurrent Set type available. Just
         // use the keys if checking for a type.
         private readonly ConcurrentDictionary<Type, bool> _ignoredExceptionTypes = new ConcurrentDictionary<Type, bool>();
@@ -96,6 +89,14 @@ namespace Hudl.Mjolnir.Command
             }
         }
 
+        /// <summary>
+        /// Ignored exception types won't count toward breakers tripping or other error counters.
+        /// Useful for things like validation, where the system isn't having any problems and the
+        /// caller needs to validate before invoking. This list is most applicable when using
+        /// [Command] attributes, since extending Command offers the ability to catch these types
+        /// specifically within Execute() - though there may still be some benefit in extended
+        /// Commands for validation-like situations where throwing is still desired.
+        /// </summary>
         public static void IgnoreExceptions(HashSet<Type> types)
         {
             if (types == null || types.Count == 0)

--- a/Hudl.Mjolnir/Command/CommandContext.cs
+++ b/Hudl.Mjolnir/Command/CommandContext.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using Hudl.Config;
 using Hudl.Mjolnir.Breaker;
 using Hudl.Mjolnir.External;
@@ -59,6 +60,17 @@ namespace Hudl.Mjolnir.Command
         private readonly ConcurrentDictionary<GroupKey, Lazy<IIsolationThreadPool>> _pools = new ConcurrentDictionary<GroupKey, Lazy<IIsolationThreadPool>>();
         private readonly ConcurrentDictionary<GroupKey, Lazy<IIsolationSemaphore>> _fallbackSemaphores = new ConcurrentDictionary<GroupKey, Lazy<IIsolationSemaphore>>();
 
+        // These exception types won't count toward breakers tripping or other error counters.
+        // Useful for things like validation, where the system isn't having any problems and the
+        // caller needs to validate before invoking. This list is most applicable when using
+        // [Command] attributes, since extending Command offers the ability to catch these types
+        // specifically within Execute() - though there may still be some benefit in extended
+        // Commands for validation-like situations where throwing is still desired.
+        //
+        // This is a Dictionary only because there's no great concurrent Set type available. Just
+        // use the keys if checking for a type.
+        private readonly ConcurrentDictionary<Type, bool> _ignoredExceptionTypes = new ConcurrentDictionary<Type, bool>();
+        
         private IStats _stats = new IgnoringStats();
 
         private CommandContext() {}
@@ -82,6 +94,24 @@ namespace Hudl.Mjolnir.Command
                 }
                 Instance._stats = value;
             }
+        }
+
+        public static void IgnoreExceptions(HashSet<Type> types)
+        {
+            if (types == null || types.Count == 0)
+            {
+                return;
+            }
+
+            foreach (var type in types)
+            {
+                Instance._ignoredExceptionTypes.TryAdd(type, true);
+            }
+        }
+
+        internal static bool IsExceptionIgnored(Type type)
+        {
+            return Instance._ignoredExceptionTypes.ContainsKey(type);
         }
 
         internal static ICircuitBreaker GetCircuitBreaker(GroupKey key)

--- a/Hudl.Mjolnir/Properties/AssemblyInfo.cs
+++ b/Hudl.Mjolnir/Properties/AssemblyInfo.cs
@@ -27,10 +27,10 @@ using System.Runtime.InteropServices;
 [assembly: Guid("97b23684-6c4a-4749-b307-5867cbce2dff")]
 
 // Used for NuGet packaging, uses semantic versioning: major.minor.patch-prerelease.
-[assembly: AssemblyInformationalVersion("2.2.0")]
+[assembly: AssemblyInformationalVersion("2.3.0")]
 
 // Keep this the same as AssemblyInformationalVersion.
-[assembly: AssemblyFileVersion("2.2.0")]
+[assembly: AssemblyFileVersion("2.3.0")]
 
 // ONLY change this when the major version changes; never with minor/patch/build versions.
 // It'll almost always be the major version followed by three zeroes (e.g. 1.0.0.0).


### PR DESCRIPTION
Particularly with `[Command]`, there can be times where an exception (e.g. an input validation error) gets thrown from `ExecuteAsync()`, but we shouldn't increment the breaker error count because there's actually nothing wrong with the service.

Add the ability to register a list of ignored exception types, which will be counted as success instead of failure.

A future consideration would be to add a third metric (alongside success and failure) to track these independently - I don't see the need for that just yet.