### PR TITLE
Func<TResult> as an alternative to Command inheritance

### DIFF
--- a/Hudl.Mjolnir/Command/DelegateAsyncCommand.cs
+++ b/Hudl.Mjolnir/Command/DelegateAsyncCommand.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Hudl.Mjolnir.Command
+{
+    internal class DelegateAsyncCommand<TResult> : AsyncCommand<TResult>
+    {
+        private readonly Func<CancellationToken?, Task<TResult>> _func;
+
+        public DelegateAsyncCommand(string group, Func<CancellationToken?, Task<TResult>> func) : base(group, group, TimeSpan.FromMilliseconds(2000))
+        {
+            _func = func ?? throw new ArgumentNullException(nameof(func));
+        }
+
+        public override Task<TResult> ExecuteAsync(CancellationToken cancellationToken)
+        {
+            return _func(cancellationToken);
+        }
+    }
+}

--- a/Hudl.Mjolnir/Command/DelegateSyncCommand.cs
+++ b/Hudl.Mjolnir/Command/DelegateSyncCommand.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Threading;
+
+namespace Hudl.Mjolnir.Command
+{
+    internal class DelegateSyncCommand<TResult> : SyncCommand<TResult>
+    {
+        private readonly Func<CancellationToken?, TResult> _func;
+
+        public DelegateSyncCommand(string group, Func<CancellationToken?, TResult> func) : base(group, group, TimeSpan.FromMilliseconds(2000))
+        {
+            _func = func ?? throw new ArgumentNullException(nameof(func));
+        }
+
+        public override TResult Execute(CancellationToken cancellationToken)
+        {
+            return _func(cancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
We have some situations (e.g. adapter code) where it's easier to work only with interfaces. This PR experiments with overloads to `Invoke*()` methods that take `Func<TResult>` delegates instead of a class that implements `SyncCommand` or `AsyncCommand`.

Opening for review and comment. This may be merged into #60.