### PR TITLE
v3.1.1 to get proper metadata into nuget.org

### DIFF
--- a/src/Hudl.Mjolnir/Hudl.Mjolnir.csproj
+++ b/src/Hudl.Mjolnir/Hudl.Mjolnir.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <VersionPrefix>3.1.0</VersionPrefix>
-    <FileVersion>3.1.0</FileVersion>
+    <VersionPrefix>3.1.1</VersionPrefix>
+    <FileVersion>3.1.1</FileVersion>
     <AssemblyVersion>3.0.0.0</AssemblyVersion>
     <TargetFrameworks>netstandard1.2</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>


### PR DESCRIPTION
I published v3.1.0 to nuget.org and was then unable to edit the metadata on the package and also unable to delete the version. So unfortunately this is a patch version update with no significant changes other than the version number!