### PR TITLE
Bulkheads in Metrics Only mode

### DIFF
--- a/src/Hudl.Mjolnir/Command/BulkheadInvoker.cs
+++ b/src/Hudl.Mjolnir/Command/BulkheadInvoker.cs
@@ -53,7 +53,7 @@ namespace Hudl.Mjolnir.Command
                 if (!onlyMetrics) throw new BulkheadRejectedException();
             }
 
-            _metricEvents.EnterBulkhead(bulkhead.Name, command.Name);
+            if (!onlyMetrics) _metricEvents.EnterBulkhead(bulkhead.Name, command.Name);
 
             // This stopwatch should begin stopped (hence the constructor instead of the usual
             // Stopwatch.StartNew(). We'll only use it if we aren't using circuit breakers.
@@ -77,10 +77,11 @@ namespace Hudl.Mjolnir.Command
             }
             finally
             {
-                if (!onlyMetrics) bulkhead.Release();
-
-                _metricEvents.LeaveBulkhead(bulkhead.Name, command.Name);
-
+                if (!onlyMetrics)
+                {
+                    bulkhead.Release();
+                    _metricEvents.LeaveBulkhead(bulkhead.Name, command.Name);
+                }
                 // If not executed here, the circuit breaker invoker will set the execution time.
                 if (executedHere)
                 {
@@ -101,7 +102,7 @@ namespace Hudl.Mjolnir.Command
                 if (!onlyMetrics) throw new BulkheadRejectedException();
             }
 
-            _metricEvents.EnterBulkhead(bulkhead.Name, command.Name);
+            if (!onlyMetrics) _metricEvents.EnterBulkhead(bulkhead.Name, command.Name);
 
             // This stopwatch should begin stopped (hence the constructor instead of the usual
             // Stopwatch.StartNew(). We'll only use it if we aren't using circuit breakers.
@@ -125,10 +126,11 @@ namespace Hudl.Mjolnir.Command
             }
             finally
             {
-                if (!onlyMetrics) bulkhead.Release();
-
-                _metricEvents.LeaveBulkhead(bulkhead.Name, command.Name);
-
+                if (!onlyMetrics)
+                {
+                    bulkhead.Release();
+                    _metricEvents.LeaveBulkhead(bulkhead.Name, command.Name);
+                }
                 // If not executed here, the circuit breaker invoker will set the execution time.
                 if (executedHere)
                 {

--- a/src/Hudl.Mjolnir/Command/BulkheadInvoker.cs
+++ b/src/Hudl.Mjolnir/Command/BulkheadInvoker.cs
@@ -48,8 +48,9 @@ namespace Hudl.Mjolnir.Command
 
             if (!bulkhead.TryEnter())
             {
+                var onlyMetrics = _config.BulkheadMetricsOnly || _config.GetBulkheadConfiguration(command.BulkheadKey.Name).MetricsOnly;
                 _metricEvents.RejectedByBulkhead(bulkhead.Name, command.Name);
-                throw new BulkheadRejectedException();
+                if (!onlyMetrics) throw new BulkheadRejectedException();
             }
 
             _metricEvents.EnterBulkhead(bulkhead.Name, command.Name);

--- a/src/Hudl.Mjolnir/Command/CommandInvoker.cs
+++ b/src/Hudl.Mjolnir/Command/CommandInvoker.cs
@@ -314,7 +314,7 @@ namespace Hudl.Mjolnir.Command
             if (_constructorCount > 1)
             {
                 // This should be a Warn but I don't want to make a breaking change right now just for a log message. 
-                _log.Info($"{_constructorCount} {nameof(CommandInvoker)} classes have been constructed in this application. It is advisable to use the CommandInvoker as a Singleton.");
+                _log.Error($"{_constructorCount} {nameof(CommandInvoker)} classes have been constructed in this application. It is advisable to use the CommandInvoker as a Singleton.");
             }
         }
 

--- a/src/Hudl.Mjolnir/Command/CommandInvoker.cs
+++ b/src/Hudl.Mjolnir/Command/CommandInvoker.cs
@@ -260,6 +260,7 @@ namespace Hudl.Mjolnir.Command
 
         private readonly ICircuitBreakerFactory _circuitBreakerFactory;
         private readonly IBulkheadFactory _bulkheadFactory;
+        private static volatile int _constructorCount;
 
         public CommandInvoker()
             : this(null, new DefaultMjolnirLogFactory(), new IgnoringMetricEvents(), null, null)
@@ -309,6 +310,12 @@ namespace Hudl.Mjolnir.Command
 
             var breakerInvoker = new BreakerInvoker(_circuitBreakerFactory, _metricEvents, _breakerExceptionHandler);
             _bulkheadInvoker = bulkheadInvoker ?? new BulkheadInvoker(breakerInvoker, _bulkheadFactory, _metricEvents, _config);
+            _constructorCount++;
+            if (_constructorCount > 1)
+            {
+                // This should be a Warn but I don't want to make a breaking change right now just for a log message. 
+                _log.Info($"{_constructorCount} {nameof(CommandInvoker)} classes have been constructed in this application. It is advisable to use the CommandInvoker as a Singleton.");
+            }
         }
 
         public Task<TResult> InvokeThrowAsync<TResult>(AsyncCommand<TResult> command)

--- a/src/Hudl.Mjolnir/Config/BulkheadConfiguration.cs
+++ b/src/Hudl.Mjolnir/Config/BulkheadConfiguration.cs
@@ -8,6 +8,15 @@
         /// </summary>
         public virtual int MaxConcurrent { get; set; }
 
+        /// <summary>
+        /// This flag will stop a BulkheadRejectionException being thrown and will continue to execute on the command. 
+        /// However the IMetricsEvents.RejectedByBulkhead() method will still be invoked. The main purpose of this 
+        /// configuration is to enable diagnostics and greater visibility into the behaviour of a system so that 
+        /// bulkhead concurrency levels can be tuned more easily. 
+        /// </summary>
+        /// <returns></returns>
+        public virtual bool MetricsOnly { get; set; }
+
         public BulkheadConfiguration()
         {
             // Set default value

--- a/src/Hudl.Mjolnir/Config/MjolnirConfiguration.cs
+++ b/src/Hudl.Mjolnir/Config/MjolnirConfiguration.cs
@@ -24,6 +24,15 @@ namespace Hudl.Mjolnir.Config
         /// </summary>
         public virtual bool IgnoreTimeouts { get; set; }
 
+        /// <summary>
+        /// Global Killswitch For Bulkhead rejections - With this set to true Mjolnir will not throw any BulkheadRejectedExceptions,
+        /// and the command will continue to execute. However the IMetricEvents.RejectedByBulkhead() will still be invoked. 
+        /// The main purpose of this configuration would be for diagnostics, giving you the ability to tune the MaxCurrency levels for each bulkhead 
+        /// based on observed metrics.
+        /// </summary>
+        /// <returns></returns>
+        public virtual bool BulkheadMetricsOnly { get; set; }
+
 
         /// <summary>
         /// Default Timeouts for commands.

--- a/src/Hudl.Mjolnir/Events/GaugeLogMetrics.cs
+++ b/src/Hudl.Mjolnir/Events/GaugeLogMetrics.cs
@@ -1,0 +1,115 @@
+using System.Collections.Concurrent;
+using Hudl.Mjolnir.External;
+
+namespace Hudl.Mjolnir.Events
+{
+    public class GaugeLogMetrics : IMetricEvents
+    {
+        private IMjolnirLog<GaugeLogMetrics> _diagnosticLog;
+        private IMjolnirLog<GaugeLogMetrics> _concurrencyExceededLog;
+        private IMjolnirLog<GaugeLogMetrics> _breakerTrippedLog;
+        private IMjolnirLog<GaugeLogMetrics> _bulkheadGaugeLog;
+        private IMjolnirLog<GaugeLogMetrics> _breakerGaugeLog;
+        private ConcurrentDictionary<string, int> _currentBulkheadsRejected;
+        public GaugeLogMetrics(IMjolnirLogFactory logFactory)
+        {
+            _diagnosticLog = logFactory.CreateLog<GaugeLogMetrics>();
+            _diagnosticLog.SetLogName($"{nameof(GaugeLogMetrics)}.Diagnostic");
+            _concurrencyExceededLog = logFactory.CreateLog<GaugeLogMetrics>();
+            _concurrencyExceededLog.SetLogName($"{nameof(GaugeLogMetrics)}.BulkheadConcurrencyExceeded");
+            _breakerTrippedLog = logFactory.CreateLog<GaugeLogMetrics>();
+            _breakerTrippedLog.SetLogName($"{nameof(GaugeLogMetrics)}.BreakerTripped");
+            _bulkheadGaugeLog = logFactory.CreateLog<GaugeLogMetrics>();
+            _bulkheadGaugeLog.SetLogName($"{nameof(GaugeLogMetrics)}.BulkheadGauge");
+            _breakerGaugeLog = logFactory.CreateLog<GaugeLogMetrics>();
+            _breakerGaugeLog.SetLogName($"{nameof(GaugeLogMetrics)}.BreakerGauge");
+            _currentBulkheadsRejected = new ConcurrentDictionary<string, int>();
+        }
+
+        public void BreakerFailureCount(string breakerName, string commandName)
+        {
+            _diagnosticLog.Debug($"BreakerFailureCount - [Breaker={breakerName}, Command={commandName}]");
+        }
+
+        public void BreakerFixed(string breakerName)
+        {
+            var log = $"BreakerFixed - [Breaker={breakerName}]";
+            _diagnosticLog.Debug(log);
+            _breakerTrippedLog.Debug(log);
+        }
+
+        public void BreakerGauge(string breakerName, long configuredMinimumOperations, long configuredWindowMillis, int configuredThresholdPercent, long configuredTrippedDurationMillis, bool configuredForceTripped, bool configuredForceFixed, bool isTripped, long windowSuccessCount, long windowFailureCount)
+        {
+            var log = $"BreakerGauge - [Breaker={breakerName}, ConfiguredMinimumOperations={configuredMinimumOperations}, ConfiguredWindowMs={configuredWindowMillis}, ConfiguredThresholdPercent={configuredThresholdPercent}, ConfiguredTrippedDurationMs={configuredTrippedDurationMillis}, ConfiguredForceTripped={configuredForceTripped}, ConfiguredForcedFixed={configuredForceFixed}, IsTripped={isTripped}, WindowSuccessCount={windowSuccessCount}, WindowFailureCount={windowFailureCount}]";
+            _diagnosticLog.Debug(log);
+            _breakerGaugeLog.Debug(log);
+            if (isTripped)
+            {
+                _breakerTrippedLog.Debug(log);
+            }
+        }
+
+        public void BreakerSuccessCount(string breakerName, string commandName)
+        {
+            _diagnosticLog.Debug($"BreakerSuccessCount - [Breaker={breakerName}, Command={commandName}]");
+        }
+
+        public void BreakerTripped(string breakerName)
+        {
+            var log = $"BreakerTripped - [Breaker={breakerName}]";
+            _diagnosticLog.Debug(log);
+            _breakerTrippedLog.Debug(log);
+        }
+
+        public void BulkheadGauge(string bulkheadName, string bulkheadType, int maxConcurrent, int countAvailable)
+        {
+            var gaugeLog = $"BulkheadGauge - [Bulkhead={bulkheadName}, BulkheadType={bulkheadType}, MaxConcurrent={maxConcurrent}, CountAvailable={countAvailable}]";
+            _diagnosticLog.Debug(gaugeLog);
+            _bulkheadGaugeLog.Debug(gaugeLog);
+            if (countAvailable == 0)
+            {
+                _concurrencyExceededLog.Debug(gaugeLog);
+            }
+            // Log the current rejections that occurred since the last gauge
+            if (_currentBulkheadsRejected.TryGetValue(bulkheadName, out int currentCount))
+            {
+                if (currentCount > 0)
+                {
+                    _concurrencyExceededLog.Debug($"BulkheadRejections since last gauge - [Bulkhead={bulkheadName}, BulkheadType={bulkheadType}, MaxConcurrent={maxConcurrent}, CountAvailable={countAvailable}, Rejections={currentCount}]");
+                    // Remove the rejections we've just logged from the current rejection count
+                    _currentBulkheadsRejected.AddOrUpdate(bulkheadName, 0, (b, c) => c - currentCount);
+                }
+            }
+        }
+
+        public void CommandInvoked(string commandName, double invokeMillis, double executeMillis, string status, string failureAction)
+        {
+            _diagnosticLog.Debug($"CommandInvoked - [Command={commandName}, InvokeMs={invokeMillis}, ExecuteMs={executeMillis}, FailureAction={failureAction}]");
+        }
+
+        public void EnterBulkhead(string bulkheadName, string commandName)
+        {
+            _diagnosticLog.Debug($"EnterBulkhead - [Bulkhead={bulkheadName}, Command={commandName}]");
+        }
+
+        public void LeaveBulkhead(string bulkheadName, string commandName)
+        {
+            _diagnosticLog.Debug($"LeaveBulkhead - [Bulkhead={bulkheadName}, Command={commandName}]");
+        }
+
+        public void RejectedByBreaker(string breakerName, string commandName)
+        {
+            var log = $"RejectedByBreaker - [Breaker={breakerName}, Command={commandName}]";
+            _diagnosticLog.Debug(log);
+            _breakerTrippedLog.Debug(log);
+        }
+
+        public void RejectedByBulkhead(string bulkheadName, string commandName)
+        {
+            var log = $"RejectedByBulkhead - [Bulkhead={bulkheadName}, Command={commandName}]";
+            _diagnosticLog.Debug(log);
+            _concurrencyExceededLog.Debug(log);
+            _currentBulkheadsRejected.AddOrUpdate(bulkheadName, 1, (bh, current) => current++);
+        }
+    }
+}

--- a/src/Hudl.Mjolnir/Events/GaugeLogMetrics.cs
+++ b/src/Hudl.Mjolnir/Events/GaugeLogMetrics.cs
@@ -109,7 +109,7 @@ namespace Hudl.Mjolnir.Events
             var log = $"RejectedByBulkhead - [Bulkhead={bulkheadName}, Command={commandName}]";
             _diagnosticLog.Debug(log);
             _concurrencyExceededLog.Debug(log);
-            _currentBulkheadsRejected.AddOrUpdate(bulkheadName, 1, (bh, current) => current++);
+            _currentBulkheadsRejected.AddOrUpdate(bulkheadName, 1, (bh, current) => ++current);
         }
     }
 }

--- a/src/Hudl.Mjolnir/Hudl.Mjolnir.csproj
+++ b/src/Hudl.Mjolnir/Hudl.Mjolnir.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <VersionPrefix>3.1.1</VersionPrefix>
-    <FileVersion>3.1.1</FileVersion>
+    <VersionPrefix>3.2.0</VersionPrefix>
+    <FileVersion>3.2.0</FileVersion>
     <AssemblyVersion>3.0.0.0</AssemblyVersion>
     <TargetFrameworks>netstandard1.2</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/tests/unit/Hudl.Mjolnir.Tests/Command/BulkheadInvokerTests.cs
+++ b/tests/unit/Hudl.Mjolnir.Tests/Command/BulkheadInvokerTests.cs
@@ -778,9 +778,9 @@ namespace Hudl.Mjolnir.Tests.Command
                 };
                 var invoker = new BulkheadInvoker(mockBreakerInvoker.Object, mockBulkheadFactory.Object, mockMetricEvents.Object, config);
                 var result = await invoker.ExecuteWithBulkheadAsync(command, CancellationToken.None);
-                mockMetricEvents.Verify(i => i.RejectedByBulkhead(key, $"{key}.{nameof(ConfigurableKeyAsyncCommand)}"));
-                mockMetricEvents.Verify(i => i.EnterBulkhead(key, $"{key}.{nameof(ConfigurableKeyAsyncCommand)}"));
-                mockMetricEvents.Verify(i => i.LeaveBulkhead(key, $"{key}.{nameof(ConfigurableKeyAsyncCommand)}"));
+                mockMetricEvents.Verify(i => i.RejectedByBulkhead(key, $"{key}.{nameof(ConfigurableKeyAsyncCommand).Replace("Command", "")}"));
+                mockMetricEvents.Verify(i => i.EnterBulkhead(key, $"{key}.{nameof(ConfigurableKeyAsyncCommand).Replace("Command", "")}"));
+                mockMetricEvents.Verify(i => i.LeaveBulkhead(key, $"{key}.{nameof(ConfigurableKeyAsyncCommand).Replace("Command", "")}"));
             }
         }
 

--- a/tests/unit/Hudl.Mjolnir.Tests/Command/BulkheadInvokerTests.cs
+++ b/tests/unit/Hudl.Mjolnir.Tests/Command/BulkheadInvokerTests.cs
@@ -143,7 +143,7 @@ namespace Hudl.Mjolnir.Tests.Command
                 var mockBulkheadFactory = new Mock<IBulkheadFactory>(MockBehavior.Strict);
                 mockBulkheadFactory.Setup(m => m.GetBulkhead(groupKey)).Returns(mockBulkhead.Object);
 
-                var mockConfig = new MjolnirConfiguration {UseCircuitBreakers = true};
+                var mockConfig = new MjolnirConfiguration { UseCircuitBreakers = true };
 
                 // The breaker invoker behavior doesn't matter here, we shouldn't get to the point
                 // where we try to use it.
@@ -175,7 +175,7 @@ namespace Hudl.Mjolnir.Tests.Command
                 var mockBulkheadFactory = new Mock<IBulkheadFactory>(MockBehavior.Strict);
                 mockBulkheadFactory.Setup(m => m.GetBulkhead(groupKey)).Returns(mockBulkhead.Object);
 
-                var mockConfig = new MjolnirConfiguration {UseCircuitBreakers = true};
+                var mockConfig = new MjolnirConfiguration { UseCircuitBreakers = true };
                 // The breaker invoker behavior doesn't matter here, we shouldn't get to the point
                 // where we try to use it. Pass a "false" value for useCircuitBreakers to help
                 // ensure that.
@@ -210,7 +210,7 @@ namespace Hudl.Mjolnir.Tests.Command
                 var mockBulkheadFactory = new Mock<IBulkheadFactory>(MockBehavior.Strict);
                 mockBulkheadFactory.Setup(m => m.GetBulkhead(groupKey)).Returns(mockBulkhead.Object);
 
-                var mockConfig = new MjolnirConfiguration {UseCircuitBreakers = false};
+                var mockConfig = new MjolnirConfiguration { UseCircuitBreakers = false };
 
                 // The breaker invoker behavior doesn't matter here, we shouldn't get to the point
                 // where we try to use it. Pass a "false" value for useCircuitBreakers to help
@@ -244,7 +244,7 @@ namespace Hudl.Mjolnir.Tests.Command
                 var mockBulkheadFactory = new Mock<IBulkheadFactory>(MockBehavior.Strict);
                 mockBulkheadFactory.Setup(m => m.GetBulkhead(groupKey)).Returns(mockBulkhead.Object);
 
-                var mockConfig = new MjolnirConfiguration {UseCircuitBreakers = false};
+                var mockConfig = new MjolnirConfiguration { UseCircuitBreakers = false };
 
                 // Pass false for useCircuitBreakers to bypass the breaker; we're testing that here.
                 var invoker = new BulkheadInvoker(mockBreakerInvoker.Object, mockBulkheadFactory.Object, mockMetricEvents.Object, mockConfig);
@@ -277,7 +277,7 @@ namespace Hudl.Mjolnir.Tests.Command
                 var mockBulkheadFactory = new Mock<IBulkheadFactory>(MockBehavior.Strict);
                 mockBulkheadFactory.Setup(m => m.GetBulkhead(groupKey)).Returns(mockBulkhead.Object);
 
-                var mockConfig = new MjolnirConfiguration {UseCircuitBreakers = false};
+                var mockConfig = new MjolnirConfiguration { UseCircuitBreakers = false };
 
                 // Pass false for useCircuitBreakers to bypass the breaker; we're testing that here.
                 var invoker = new BulkheadInvoker(mockBreakerInvoker.Object, mockBulkheadFactory.Object, mockMetricEvents.Object, mockConfig);
@@ -315,7 +315,7 @@ namespace Hudl.Mjolnir.Tests.Command
                 mockBreakerInvoker.Setup(m => m.ExecuteWithBreakerAsync(command, It.IsAny<CancellationToken>()))
                     .Returns(Task.FromResult(true));
 
-                var mockConfig = new MjolnirConfiguration {UseCircuitBreakers = true};
+                var mockConfig = new MjolnirConfiguration { UseCircuitBreakers = true };
 
                 // Pass true for useCircuitBreakers, we need to test that behavior here.
                 var invoker = new BulkheadInvoker(mockBreakerInvoker.Object, mockBulkheadFactory.Object, mockMetricEvents.Object, mockConfig);
@@ -354,7 +354,7 @@ namespace Hudl.Mjolnir.Tests.Command
                 mockBreakerInvoker.Setup(m => m.ExecuteWithBreakerAsync(command, It.IsAny<CancellationToken>()))
                     .Throws(new ExpectedTestException(command.Name));
 
-                var mockConfig = new MjolnirConfiguration {UseCircuitBreakers = true};
+                var mockConfig = new MjolnirConfiguration { UseCircuitBreakers = true };
 
                 // Pass true for useCircuitBreakers, we need to test that behavior here.
                 var invoker = new BulkheadInvoker(mockBreakerInvoker.Object, mockBulkheadFactory.Object, mockMetricEvents.Object, mockConfig);
@@ -491,7 +491,7 @@ namespace Hudl.Mjolnir.Tests.Command
                 var mockBulkheadFactory = new Mock<IBulkheadFactory>(MockBehavior.Strict);
                 mockBulkheadFactory.Setup(m => m.GetBulkhead(groupKey)).Returns(mockBulkhead.Object);
 
-                var mockConfig = new MjolnirConfiguration {UseCircuitBreakers = true};
+                var mockConfig = new MjolnirConfiguration { UseCircuitBreakers = true };
                 // The breaker invoker behavior doesn't matter here, we shouldn't get to the point
                 // where we try to use it.
                 var invoker = new BulkheadInvoker(mockBreakerInvoker.Object, mockBulkheadFactory.Object, mockMetricEvents.Object, mockConfig);
@@ -522,7 +522,7 @@ namespace Hudl.Mjolnir.Tests.Command
                 var mockBulkheadFactory = new Mock<IBulkheadFactory>(MockBehavior.Strict);
                 mockBulkheadFactory.Setup(m => m.GetBulkhead(groupKey)).Returns(mockBulkhead.Object);
 
-                var mockConfig = new MjolnirConfiguration {UseCircuitBreakers = false};
+                var mockConfig = new MjolnirConfiguration { UseCircuitBreakers = false };
 
                 // The breaker invoker behavior doesn't matter here, we shouldn't get to the point
                 // where we try to use it. Pass a "false" value for useCircuitBreakers to help
@@ -558,7 +558,7 @@ namespace Hudl.Mjolnir.Tests.Command
                 var mockBulkheadFactory = new Mock<IBulkheadFactory>(MockBehavior.Strict);
                 mockBulkheadFactory.Setup(m => m.GetBulkhead(groupKey)).Returns(mockBulkhead.Object);
 
-                var mockConfig = new MjolnirConfiguration {UseCircuitBreakers = false};
+                var mockConfig = new MjolnirConfiguration { UseCircuitBreakers = false };
                 // The breaker invoker behavior doesn't matter here, we shouldn't get to the point
                 // where we try to use it. Pass a "false" value for useCircuitBreakers to help
                 // ensure that.
@@ -591,7 +591,7 @@ namespace Hudl.Mjolnir.Tests.Command
                 var mockBulkheadFactory = new Mock<IBulkheadFactory>(MockBehavior.Strict);
                 mockBulkheadFactory.Setup(m => m.GetBulkhead(groupKey)).Returns(mockBulkhead.Object);
 
-                var mockConfig = new MjolnirConfiguration {UseCircuitBreakers = false};
+                var mockConfig = new MjolnirConfiguration { UseCircuitBreakers = false };
                 // Pass false for useCircuitBreakers to bypass the breaker; we're testing that here.
                 var invoker = new BulkheadInvoker(mockBreakerInvoker.Object, mockBulkheadFactory.Object, mockMetricEvents.Object, mockConfig);
                 var command = new ConfigurableKeyCommand(key);
@@ -623,7 +623,7 @@ namespace Hudl.Mjolnir.Tests.Command
                 var mockBulkheadFactory = new Mock<IBulkheadFactory>(MockBehavior.Strict);
                 mockBulkheadFactory.Setup(m => m.GetBulkhead(groupKey)).Returns(mockBulkhead.Object);
 
-                var mockConfig = new MjolnirConfiguration {UseCircuitBreakers = false};
+                var mockConfig = new MjolnirConfiguration { UseCircuitBreakers = false };
                 // Pass false for useCircuitBreakers to bypass the breaker; we're testing that here.
                 var invoker = new BulkheadInvoker(mockBreakerInvoker.Object, mockBulkheadFactory.Object, mockMetricEvents.Object, mockConfig);
                 var command = new ConfigurableKeyThrowingCommand(key);
@@ -660,7 +660,7 @@ namespace Hudl.Mjolnir.Tests.Command
                 mockBreakerInvoker.Setup(m => m.ExecuteWithBreaker(command, It.IsAny<CancellationToken>()))
                     .Returns(true);
 
-                var mockConfig = new MjolnirConfiguration {UseCircuitBreakers = true};
+                var mockConfig = new MjolnirConfiguration { UseCircuitBreakers = true };
                 // Pass true for useCircuitBreakers, we need to test that behavior here.
                 var invoker = new BulkheadInvoker(mockBreakerInvoker.Object, mockBulkheadFactory.Object, mockMetricEvents.Object, mockConfig);
 
@@ -698,7 +698,7 @@ namespace Hudl.Mjolnir.Tests.Command
                 mockBreakerInvoker.Setup(m => m.ExecuteWithBreaker(command, It.IsAny<CancellationToken>()))
                     .Throws(new ExpectedTestException(command.Name));
 
-                var mockConfig = new MjolnirConfiguration {UseCircuitBreakers = true};
+                var mockConfig = new MjolnirConfiguration { UseCircuitBreakers = true };
                 // Pass true for useCircuitBreakers, we need to test that behavior here.
                 var invoker = new BulkheadInvoker(mockBreakerInvoker.Object, mockBulkheadFactory.Object, mockMetricEvents.Object, mockConfig);
 
@@ -707,6 +707,80 @@ namespace Hudl.Mjolnir.Tests.Command
                 Assert.Throws<ExpectedTestException>(() => invoker.ExecuteWithBulkhead(command, CancellationToken.None));
 
                 Assert.Equal(0, command.ExecutionTimeMillis);
+            }
+
+            [Fact]
+            public async Task DoesntThrowRejectionException_When_BulkheadInMetricsMode()
+            {
+                var mockBreakerInvoker = new Mock<IBreakerInvoker>();
+                var mockMetricEvents = new Mock<IMetricEvents>();
+                var key = "key";
+                var groupKey = GroupKey.Named(key);
+                var mockBulkhead = new Mock<ISemaphoreBulkhead>();
+                mockBulkhead.Setup(m => m.TryEnter()).Returns(false);
+                mockBulkhead.SetupGet(m => m.Name).Returns(key);
+                var mockBulkheadFactory = new Mock<IBulkheadFactory>(MockBehavior.Strict);
+                mockBulkheadFactory.Setup(m => m.GetBulkhead(groupKey)).Returns(mockBulkhead.Object);
+                var command = new ConfigurableKeyAsyncCommand(key);
+                var config = new MjolnirConfiguration()
+                {
+                    BulkheadConfigurations = new Dictionary<string, BulkheadConfiguration> { { key, new BulkheadConfiguration { MetricsOnly = true } } }
+                };
+                var invoker = new BulkheadInvoker(mockBreakerInvoker.Object, mockBulkheadFactory.Object, mockMetricEvents.Object, config);
+                var result = await invoker.ExecuteWithBulkheadAsync(command, CancellationToken.None);
+                mockBulkhead.Verify(i => i.TryEnter(), Times.Once);
+                // Make sure that we don't Release in this case otherwise this would increase the semaphore count too much.
+                mockBulkhead.Verify(i => i.Release(), Times.Never);
+            }
+
+            [Fact]
+            public async Task DoesntThrowRejectionException_When_GlobalBulkheadInMetricsMode()
+            {
+                var mockBreakerInvoker = new Mock<IBreakerInvoker>();
+                var mockMetricEvents = new Mock<IMetricEvents>();
+                var key = "key";
+                var groupKey = GroupKey.Named(key);
+                var mockBulkhead = new Mock<ISemaphoreBulkhead>();
+                mockBulkhead.Setup(m => m.TryEnter()).Returns(false);
+                mockBulkhead.SetupGet(m => m.Name).Returns(key);
+                var mockBulkheadFactory = new Mock<IBulkheadFactory>(MockBehavior.Strict);
+                mockBulkheadFactory.Setup(m => m.GetBulkhead(groupKey)).Returns(mockBulkhead.Object);
+                var command = new ConfigurableKeyAsyncCommand(key);
+                var config = new MjolnirConfiguration()
+                {
+                    BulkheadMetricsOnly = true,
+                    BulkheadConfigurations = new Dictionary<string, BulkheadConfiguration> { { key, new BulkheadConfiguration { MetricsOnly = false } } }
+                };
+                var invoker = new BulkheadInvoker(mockBreakerInvoker.Object, mockBulkheadFactory.Object, mockMetricEvents.Object, config);
+                var result = await invoker.ExecuteWithBulkheadAsync(command, CancellationToken.None);
+                mockBulkhead.Verify(i => i.TryEnter(), Times.Once);
+                // Make sure that we don't Release in this case otherwise this would increase the semaphore count too much.
+                mockBulkhead.Verify(i => i.Release(), Times.Never);
+            }
+
+            [Fact]
+            public async Task CallsMetricsEvents_When_GlobalBulkheadInMetricsMode()
+            {
+                var mockBreakerInvoker = new Mock<IBreakerInvoker>();
+                var mockMetricEvents = new Mock<IMetricEvents>();
+                var key = "key";
+                var groupKey = GroupKey.Named(key);
+                var mockBulkhead = new Mock<ISemaphoreBulkhead>();
+                mockBulkhead.Setup(m => m.TryEnter()).Returns(false);
+                mockBulkhead.SetupGet(m => m.Name).Returns(key);
+                var mockBulkheadFactory = new Mock<IBulkheadFactory>(MockBehavior.Strict);
+                mockBulkheadFactory.Setup(m => m.GetBulkhead(groupKey)).Returns(mockBulkhead.Object);
+                var command = new ConfigurableKeyAsyncCommand(key);
+                var config = new MjolnirConfiguration()
+                {
+                    BulkheadMetricsOnly = true,
+                    BulkheadConfigurations = new Dictionary<string, BulkheadConfiguration> { { key, new BulkheadConfiguration { MetricsOnly = false } } }
+                };
+                var invoker = new BulkheadInvoker(mockBreakerInvoker.Object, mockBulkheadFactory.Object, mockMetricEvents.Object, config);
+                var result = await invoker.ExecuteWithBulkheadAsync(command, CancellationToken.None);
+                mockMetricEvents.Verify(i => i.RejectedByBulkhead(key, $"{key}.{nameof(ConfigurableKeyAsyncCommand)}"));
+                mockMetricEvents.Verify(i => i.EnterBulkhead(key, $"{key}.{nameof(ConfigurableKeyAsyncCommand)}"));
+                mockMetricEvents.Verify(i => i.LeaveBulkhead(key, $"{key}.{nameof(ConfigurableKeyAsyncCommand)}"));
             }
         }
 

--- a/tests/unit/Hudl.Mjolnir.Tests/Command/BulkheadInvokerTests.cs
+++ b/tests/unit/Hudl.Mjolnir.Tests/Command/BulkheadInvokerTests.cs
@@ -778,9 +778,9 @@ namespace Hudl.Mjolnir.Tests.Command
                 };
                 var invoker = new BulkheadInvoker(mockBreakerInvoker.Object, mockBulkheadFactory.Object, mockMetricEvents.Object, config);
                 var result = await invoker.ExecuteWithBulkheadAsync(command, CancellationToken.None);
-                mockMetricEvents.Verify(i => i.RejectedByBulkhead(key, $"{key}.{nameof(ConfigurableKeyAsyncCommand).Replace("Command", "")}"));
-                mockMetricEvents.Verify(i => i.EnterBulkhead(key, $"{key}.{nameof(ConfigurableKeyAsyncCommand).Replace("Command", "")}"));
-                mockMetricEvents.Verify(i => i.LeaveBulkhead(key, $"{key}.{nameof(ConfigurableKeyAsyncCommand).Replace("Command", "")}"));
+                mockMetricEvents.Verify(i => i.RejectedByBulkhead(key, $"{key}.{nameof(ConfigurableKeyAsyncCommand).Replace("Command", "")}"), Times.Once);
+                mockMetricEvents.Verify(i => i.EnterBulkhead(key, $"{key}.{nameof(ConfigurableKeyAsyncCommand).Replace("Command", "")}"), Times.Never);
+                mockMetricEvents.Verify(i => i.LeaveBulkhead(key, $"{key}.{nameof(ConfigurableKeyAsyncCommand).Replace("Command", "")}"), Times.Never);
             }
         }
 

--- a/tests/unit/Hudl.Mjolnir.Tests/Events/GaugeLogMetricsTests.cs
+++ b/tests/unit/Hudl.Mjolnir.Tests/Events/GaugeLogMetricsTests.cs
@@ -1,0 +1,33 @@
+using System;
+using Hudl.Mjolnir.Events;
+using Hudl.Mjolnir.External;
+using Moq;
+using Xunit;
+
+namespace Hudl.Mjolnir.Tests.Events
+{
+    public class GaugeLogMetricsTests
+    {
+        [Fact]
+        public void RejectionsLoggedInGaugeCorrectly()
+        {
+            var mockLogFactory = new Mock<IMjolnirLogFactory>();
+            var mockLogger = new Mock<IMjolnirLog<GaugeLogMetrics>>();
+            mockLogFactory.Setup(i => i.CreateLog<GaugeLogMetrics>()).Returns(mockLogger.Object);
+            var gaugeLogMetrics = new GaugeLogMetrics(mockLogFactory.Object);
+            Func<string, int, bool> logMessageCheck = (s, i) =>
+            {
+                var containsRejections = s.Contains("BulkheadRejections") && s.Contains($"Rejections={i}");
+                return containsRejections;
+            };
+            gaugeLogMetrics.RejectedByBulkhead("test", "test-command");
+            gaugeLogMetrics.RejectedByBulkhead("test", "test-command");
+            gaugeLogMetrics.RejectedByBulkhead("test", "test-command");
+            gaugeLogMetrics.BulkheadGauge("test", "test", 2, 0);
+            gaugeLogMetrics.RejectedByBulkhead("test", "test-command");
+            gaugeLogMetrics.BulkheadGauge("test", "test", 2, 0);
+            mockLogger.Verify(i => i.Debug(It.Is<string>(s => logMessageCheck(s, 3))), Times.Once);
+            mockLogger.Verify(i => i.Debug(It.Is<string>(s => logMessageCheck(s, 1))), Times.Once);
+        }
+    }
+}


### PR DESCRIPTION
**v3.2.0**

This adds the ability to put Bulkheads into a metrics only mode, through configuration at a per bulkhead or global level. 

If bulkhead concurrency isn't properly tuned in a production scenario then it's possible that you get a lot of `BulkheadRejectionExceptions` that actually would have been safe to execute without a throttle. These config keys add the ability to quickly turn off bulkhead rejections during a production scenario like this. 

We felt like it was still important to get metrics for rejections during a time when they're effectively not rejecting, as this may help with tuning the concurrency levels in the future. 

This PR also adds an `IMetricEvent` implementation, with `GaugeLogMetrics` to help with some of the diagnostic actions mentioned above. 

The wiki is being updated with relevant information in the `MARM-UpdateDocsForBulkheadMetricsOnly` branch of the wiki repo. 