### PR TITLE
Replace non threaded safe List with a ConcurrentDictionary in bulkhead factory.

### DIFF
--- a/src/Hudl.Mjolnir/Bulkhead/BulkheadFactory.cs
+++ b/src/Hudl.Mjolnir/Bulkhead/BulkheadFactory.cs
@@ -97,7 +97,7 @@ namespace Hudl.Mjolnir.Bulkhead
             private readonly GroupKey _key;
 
             private ISemaphoreBulkhead _bulkhead;
-            public ISemaphoreBulkhead Bulkhead { get { return _bulkhead; } }
+            public ISemaphoreBulkhead Bulkhead => _bulkhead;
 
             private readonly IMetricEvents _metricEvents;
             private readonly MjolnirConfiguration _config;

--- a/src/Hudl.Mjolnir/Hudl.Mjolnir.csproj
+++ b/src/Hudl.Mjolnir/Hudl.Mjolnir.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <VersionPrefix>3.2.0</VersionPrefix>
-    <FileVersion>3.2.0</FileVersion>
+    <VersionPrefix>3.2.1</VersionPrefix>
+    <FileVersion>3.2.1</FileVersion>
     <AssemblyVersion>3.0.0.0</AssemblyVersion>
     <TargetFrameworks>netstandard1.2</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/tests/unit/Hudl.Mjolnir.Tests/Bulkhead/BulkheadFactoryTests.cs
+++ b/tests/unit/Hudl.Mjolnir.Tests/Bulkhead/BulkheadFactoryTests.cs
@@ -339,8 +339,12 @@ namespace Hudl.Mjolnir.Tests.Bulkhead
         }
 
 
+        /// <summary>
+        /// This test may past even if there is a concurrency problem. It will always pass if the concurrency is working
+        /// fine. Do not ignore FAILURES!!
+        /// </summary>
         [Fact]
-        public async Task MultiThreadedInitialization_DoesNotThrow()
+        public void MultiThreadedInitialization_DoesNotThrow()
         {
             var mockMetricEvents = new Mock<IMetricEvents>(MockBehavior.Strict);
 


### PR DESCRIPTION
# Description

A List is not thread-safe. This PR is changing bulkheads subscriptions to a thread-safe concurrent dictionary.
That will eliminate race condition while creating bulkheads.

Solves https://jira.hudlnet.com/browse/POB-201 and https://jira.hudlnet.com/browse/MARVEL-2040